### PR TITLE
chore: clarify build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # kras-trans-site
+
+Static site for Kras-Trans.
+
+## Build scripts
+
+The officially supported build script lives in `tools/build.py`. It consumes
+CMS data and writes the generated site to the `dist/` directory. Run it with
+environment variables pointing at your Apps Script endpoint:
+
+```bash
+APPS_URL=<apps_script_url> APPS_KEY=<key> python tools/build.py
+```
+
+For local experiments a simplified variant is available at
+`tools/build_local.py`. It uses the same `APPS_URL` and `APPS_KEY` variables and
+also outputs to `dist/`.
+

--- a/tools/build_local.py
+++ b/tools/build_local.py
@@ -12,15 +12,19 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from slugify import slugify
 
 # --- CONFIG / ENV ---
+# Expected env vars:
+#   APPS_URL – Apps Script endpoint returning CMS JSON
+#   APPS_KEY – access key for the endpoint
 SITE_URL = os.getenv("SITE_URL", "https://krastranseu-lang.github.io/kras-trans-site").rstrip("/")
-API_URL  = os.getenv("SHEETS_JSON_URL")
-API_KEY  = os.getenv("SHEETS_API_KEY")
-OUT      = pathlib.Path("public")
+APPS_URL = os.getenv("APPS_URL")
+APPS_KEY = os.getenv("APPS_KEY")
+OUT      = pathlib.Path("dist")
 
 # --- HELPERS ---
 def fetch_data():
-    assert API_URL and API_KEY, "Missing SHEETS_JSON_URL or SHEETS_API_KEY"
-    url = f"{API_URL}?key={API_KEY}"
+    """Fetch CMS JSON from Apps Script."""
+    assert APPS_URL and APPS_KEY, "Missing APPS_URL or APPS_KEY"
+    url = f"{APPS_URL}?key={APPS_KEY}"
     r = requests.get(url, timeout=30)
     r.raise_for_status()
     return r.json()


### PR DESCRIPTION
## Summary
- move legacy build script to tools/build_local.py and align env vars
- document build process and officially support tools/build.py

## Testing
- `pip install -r requirements.txt`
- `python tools/build.py`
- `python -m py_compile tools/build_local.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5cfd16808333bf48b3077f1fd1ae