### PR TITLE
feat(header/nav): i18n-only menu + safe-area spacing, overflow scroll, a11y focus

### DIFF
--- a/assets/css/kras-global.css
+++ b/assets/css/kras-global.css
@@ -39,6 +39,15 @@
   --shadow-1: 0 4px 18px rgba(0,0,0,.08);
   --shadow-2: 0 10px 40px rgba(0,0,0,.14);
 
+  --container-max: 1280px;
+  --container-x: 16px;
+  --container-x-md: 24px;
+  --container-x-lg: 32px;
+  --container-x-xl: 40px;
+  --nav-gap-min: 12px;
+  --nav-gap-max: 24px;
+  --tap-min: 44px;
+
   color-scheme: light dark;
 }
 
@@ -102,10 +111,14 @@ body {
 /* =========================
    1) Layout
    ========================= */
-.container {
-  width: min(1120px, 100% - 2*24px);
+.container{
+  max-width: var(--container-max);
   margin-inline: auto;
+  padding-inline: var(--container-x);
 }
+@media (min-width:600px){ .container{ padding-inline: var(--container-x-md); } }
+@media (min-width:900px){ .container{ padding-inline: var(--container-x-lg); } }
+@media (min-width:1200px){ .container{ padding-inline: var(--container-x-xl); } }
 
 .section {
   position: relative;
@@ -135,30 +148,51 @@ body {
 /* =========================
    2) Header (sticky, glass)
    ========================= */
-.site-header{
-  position: sticky; top: 0; z-index: 50;
-  backdrop-filter: saturate(120%) blur(10px);
-  background: color-mix(in srgb, var(--surface) 82%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--ring) 35%, transparent);
-}
+.site-header{ position:sticky; top:0; z-index:50; backdrop-filter:saturate(1.2) blur(6px); background: color-mix(in srgb, var(--surface) 82%, transparent); border-bottom:1px solid color-mix(in srgb, var(--ring) 35%, transparent); }
 .header-grid{
-  display: grid; align-items: center; gap: 16px;
-  grid-template-columns: 1fr auto auto;
-  padding: 12px 0;
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  align-items:center;
+  column-gap: clamp(12px, 3vw, 32px);
+  padding-block: 12px;
 }
 .brand{ font-weight: 700; text-decoration: none; color: var(--text); font-size: var(--fs-500); }
 
-.nav { display: flex; align-items: center; gap: 12px; }
-.nav-list, .nav-langs{
-  display: flex; gap: 8px; align-items: center; list-style: none; margin:0; padding:0;
+.nav{ overflow:hidden; }
+.nav__list{
+  display:flex; align-items:center;
+  gap: clamp(var(--nav-gap-min), 2vw, var(--nav-gap-max));
+  overflow:auto; white-space:nowrap;
+  margin-inline:-8px; padding-inline:8px;
+  scrollbar-width:none; -ms-overflow-style:none;
 }
-.nav a{
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 8px 10px; border-radius: 10px; text-decoration: none;
+.nav__list::-webkit-scrollbar{ display:none; }
+.nav__list a{
+  display:inline-flex; align-items:center;
+  padding:10px 8px;
+  min-height: var(--tap-min);
+  line-height:1;
+  text-decoration:none;
+  white-space:nowrap;
   color: var(--text-2);
 }
-.nav a:hover{ background: var(--surface-2); color: var(--text); }
+.nav-langs{
+  display:flex; gap:8px; align-items:center; list-style:none; margin:0; padding:0;
+}
+.nav__list a:hover{ background: var(--surface-2); color: var(--text); }
 .nav .active > a{ color: var(--text); font-weight: 600; }
+
+.site-header .container{ scroll-padding-inline: 16px; }
+
+@media (pointer:coarse){
+  .nav__list a{ padding-inline:12px; }
+}
+
+.nav__list a:focus-visible{
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius:10px;
+}
 
 /* akcje w nagłówku */
 .header-actions{ display:flex; align-items:center; gap: 10px; }

--- a/assets/js/menu-builder.js
+++ b/assets/js/menu-builder.js
@@ -153,7 +153,7 @@
 
     // list
     const list = document.createElement("ul");
-    list.className = "nav-list";
+    list.className = "nav__list";
     list.setAttribute("role", "menubar");
     shell.appendChild(list);
     state.list = list;
@@ -233,7 +233,7 @@
       langWrap.appendChild(a);
     });
 
-    // overflow shadows on nav-list
+    // overflow shadows on nav__list
     attachOverflowShadows(list);
     nav.hidden = false;
   }
@@ -287,7 +287,7 @@
     // keyboard on menubar + submenus (delegated)
     state.nav.addEventListener("keydown", (e) => {
       const tgt = e.target;
-      const topItems = qsa(".nav-list > li > a, .nav-list > li > .nav-toggle", state.nav);
+      const topItems = qsa(".nav__list > li > a, .nav__list > li > .nav-toggle", state.nav);
       const idx = topItems.indexOf(tgt);
 
       // Menubar level

--- a/templates/page.html
+++ b/templates/page.html
@@ -201,34 +201,35 @@ footer{ padding:40px 20px; color:var(--muted); border-top:1px solid var(--border
 <a href="#main" class="skip">Przejdź do treści</a>
 
 <!-- ========== sekcja header ========= -->
-<header class="header" role="banner" id="top">
-  <!-- ======= komp. header ======= -->
-  <div class="section" style="padding:12px 20px">
-    <nav class="text" style="max-width:none; display:flex; align-items:center; gap:14px; justify-content:space-between">
-      <div class="brand"><a href="#top" class="btn-ghost">Kras‑Trans</a></div>
+<header class="site-header" role="banner">
+  <div class="container header-grid">
+    <a href="/" class="brand">{{ brand }}</a>
 
-      <div class="menu" style="display:flex; gap:6px; flex-wrap:wrap">
-        <a href="#onas">O nas</a>
-        <a href="#kontakt">Kontakt</a>
-        <a href="#uslugi">Usługi Transportowe</a>
-        <a href="#flota">Flota</a>
-        <a href="#praca">Praca</a>
-        <a href="#faq">FAQ</a>
-        <a href="#blog">Blog</a>
-        <a href="#vanfit">VanFit</a>
-        <a href="#wycena" class="btn primary btn--pulse">Wycena 15 min</a>
-      </div>
-
-      <div style="display:flex; align-items:center; gap:8px">
-        <button class="switch" id="d-theme" type="button" aria-checked="false" aria-label="Przełącz motyw">
-          <span class="knob" aria-hidden="true"></span>
-        </button>
-        <button id="reading-toggle" class="btn-ghost" type="button" aria-pressed="false" title="Tryb czytania">Czytanie</button>
-        <a href="tel:+48793927467" class="btn">Zadzwoń</a>
-      </div>
+    {% set _lang = (page.lang or default_lang)|lower %}
+    {% set nav_items = [] %}
+    {% for item in nav %}
+      {% if (item.lang or default_lang)|lower == _lang %}
+        {% set _ = nav_items.append(item) %}
+      {% endif %}
+    {% endfor %}
+    <nav id="site-nav" class="nav" aria-label="{{ strings.nav_main }}">
+      {% if nav_items %}
+      <ul class="nav__list">
+        {% for item in nav_items %}
+        <li><a href="{{ item.href }}">{{ item.label }}</a></li>
+        {% endfor %}
+      </ul>
+      {% endif %}
     </nav>
+
+    <div class="header-actions">
+      <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="Przełącz motyw">
+        <span class="sun" aria-hidden="true"></span>
+        <span class="moon" aria-hidden="true"></span>
+      </button>
+      <a href="tel:+48793927467" class="btn primary">Zadzwoń 24/7</a>
+    </div>
   </div>
-  <!-- ======= koniec komp. header ======= -->
 </header>
 <!-- ========== koniec header ========= -->
 


### PR DESCRIPTION
## Summary
- render header navigation solely from CMS-provided items for current language
- introduce container spacing variables and responsive safe-area padding
- add horizontal-scrolling nav with focus-visible styling and update menu builder markup

## Testing
- `python tools/build.py`
- `python -m http.server 8080 -d dist` (served site locally, verified with curl)


------
https://chatgpt.com/codex/tasks/task_e_689f623e7b3083339cfc918974fb541f