### PR TITLE
feat: add lightweight template and UI layer

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -1,154 +1,105 @@
-:root {
-  --accent-hue: 22;
-  --bg: #ffffff;
-  --ink: #1f2126;
-  --muted: #646b75;
-  --card: #ffffff;
-  --bg-alt: #eef0f2;
-}
-:root[data-theme="dark"] {
-  --bg: #0b0f17;
-  --ink: #e9eef4;
-  --muted: #a9afb9;
-  --card: #12151c;
-  --bg-alt: #0e141d;
-}
-:root[data-theme="ebook"] {
-  --bg: #F7F3E8;
-  --ink: #1C1A16;
-  --muted: #6B665E;
-  --card: #FBF8EF;
-  --bg-alt: #EFE9DA;
-  font-variation-settings: "wght" 470;
-}
-.theme-hint {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background: var(--card);
-  color: var(--ink);
-  padding: .25rem .5rem;
-  border-radius: .25rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,.1);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity .3s;
-}
-.theme-hint::after {
-  content: "";
-  position: absolute;
-  top: -6px;
-  right: 10px;
-  border: 6px solid transparent;
-  border-bottom-color: var(--card);
-}
-.theme-hint.show {
-  opacity: 1;
-}
-.bottom-dock {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: space-between;
-  padding: .25rem env(safe-area-inset-right) calc(.25rem + env(safe-area-inset-bottom)) env(safe-area-inset-left);
-  background: var(--card);
-  box-shadow: 0 -2px 6px rgba(0,0,0,.1);
-}
-.bottom-dock .dock-item {
-  flex: 1;
-  text-align: center;
-  padding: .5rem;
-  background: none;
-  border: 0;
-}
-.bottom-dock .dock-item svg {
-  width: 1.5rem;
-  height: 1.5rem;
-  fill: var(--ink);
-}
-.bottom-dock .dock-item.cta {
-  transform: translateY(-20%);
-}
-.neon {
-  position: fixed;
-  inset: 0;
-  display: none;
-  background: rgba(0,0,0,.6);
-  backdrop-filter: blur(4px);
-}
-.neon.is-open {
-  display: flex;
-}
-.neon .neon-wrap {
-  margin: auto;
-  padding: 1rem;
-  background: var(--card);
-  color: var(--ink);
-  max-height: 100%;
-  overflow: auto;
-  box-shadow: 0 0 1rem hsl(var(--accent-hue) 80% 60% / .6);
-  position: relative;
-}
-.neon .neon-close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  background: none;
-  border: 0;
-}
-.offer-stage {
-  min-height: clamp(20rem, 40vh, 40rem);
-  position: relative;
-}
-.offer-heading {
-  text-align: center;
-  transition: transform .6s, opacity .6s;
-  transform-origin: center;
-}
-.offer-reveal .cards {
-  opacity: 0;
-  transform: translateY(2rem);
-  transition: opacity .6s, transform .6s;
-}
-.offer-reveal.is-on .offer-heading {
-  transform: scaleX(0);
-  opacity: 0;
-}
-.offer-reveal.is-on .cards {
-  opacity: 1;
-  transform: translateY(0);
-}
-.cards {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(clamp(260px,80vw,340px), 1fr));
-}
-.cards--scroll {
-  display: flex;
-  overflow-x: auto;
-  scroll-snap-type: x mandatory;
-}
-.cards--scroll .card {
-  flex: 0 0 clamp(260px,80vw,340px);
-  scroll-snap-align: start;
-}
-.card .pad {
-  padding: 1rem;
-}
-.howto {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background: var(--card);
-  padding: .5rem;
-  border-radius: .25rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,.1);
-}
-@media (prefers-reduced-motion: reduce) {
-  .offer-heading,
-  .offer-reveal .cards {
-    transition: none;
+@layer base, components, utilities;
+
+@layer base {
+  :root {
+    color-scheme: light dark;
+    --accent-hue:22;
+    --bg:#ffffff;
+    --ink:#1f1f1f;
+    --muted:#6b7280;
+    --card:#ffffff;
   }
+  :root[data-theme="dark"]{
+    --bg:#0b0f17;
+    --ink:#e9edf5;
+    --muted:#8a94a7;
+    --card:#12151d;
+  }
+  :root[data-theme="ebook"]{
+    --bg:#F7F3E8;
+    --ink:#1C1A16;
+    --muted:#6B665E;
+    --card:#FBF8EF;
+  }
+  @font-face{
+    font-family:"Inter";
+    font-style:normal;
+    font-weight:100 900;
+    font-display:swap;
+    size-adjust:100%;
+    src:url("/assets/fonts/InterVariable.woff2") format("woff2-variations");
+    unicode-range:U+000-5FF;
+  }
+  html.no-motion *,
+  html.no-motion *::before,
+  html.no-motion *::after{
+    animation:none!important;
+    transition:none!important;
+  }
+  @media (prefers-reduced-motion:reduce){
+    html.no-motion{ }
+  }
+}
+
+@layer components {
+  .site-header{
+    position:sticky;top:0;z-index:40;
+    backdrop-filter:saturate(1.2) blur(8px);
+    background:color-mix(in srgb,var(--bg) 70%, transparent);
+    border-bottom:1px solid color-mix(in srgb,var(--ink) 15%, transparent);
+    overflow:clip;
+  }
+  .site-header :is(a,button){outline-offset:2px;}
+  #mega-root{position:absolute;left:0;right:0;top:100%;background:var(--card);box-shadow:0 10px 40px rgba(0,0,0,.14);}
+
+  .hero-wrap{display:grid;gap:clamp(24px,5vw,40px);}
+  @media(min-width:800px){.hero-wrap{grid-template-columns:1fr 1fr;align-items:center;}}
+  .hero-media{width:100%;height:auto;opacity:0;transition:opacity .6s ease;}
+  .hero.is-ready .hero-media{opacity:1;}
+
+  .offer-stage{min-height:clamp(32rem,60vh,48rem);position:relative;}
+  .offer-heading{display:inline-block;transform:scaleX(0);transform-origin:left;mask:linear-gradient(90deg,#000 60%,transparent);transition:transform .6s ease;}
+  .offer-reveal .cards{opacity:0;transform:translateY(40px);transition:opacity .6s ease,transform .6s ease;}
+  .offer-reveal.is-on .offer-heading{transform:scaleX(1);}
+  .offer-reveal.is-on .cards{opacity:1;transform:none;}
+
+  .cards{display:grid;gap:clamp(16px,3vw,32px);}
+  .cards--wrap{grid-auto-flow:column;}
+  .cards--scroll{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;}
+  .cards--scroll .card{flex:0 0 clamp(260px,80vw,340px);scroll-snap-align:start;}
+  .card{background:var(--card);border-radius:var(--r,16px);box-shadow:var(--shadow-1,0 4px 18px rgba(0,0,0,.08));transition:transform .3s;}
+  .card>.pad{padding:clamp(16px,3vw,24px);}
+  .card.glass{background:color-mix(in srgb,var(--card) 60%,transparent);backdrop-filter:blur(8px);}
+  .card.edge{border:1px solid color-mix(in srgb,var(--ink) 20%,transparent);}
+  .card.soft3d{box-shadow:0 6px 12px rgba(0,0,0,.12),0 1px 0 rgba(255,255,255,.05) inset;}
+  .card.illume{box-shadow:0 0 0 1px color-mix(in srgb,var(--ink) 10%,transparent),0 0 8px hsl(var(--accent-hue) 80% 60% / .35);}
+  .tilt-cards{perspective:1000px;}
+  .tilt-cards .card{transform-style:preserve-3d;}
+  .tilt-cards .card:is(:hover,:focus-within){transform:translateY(-4px) rotateX(1.5deg) rotateY(-1.5deg);}
+
+  .bottom-dock{position:fixed;bottom:0;left:0;right:0;z-index:50;display:flex;justify-content:space-around;padding:4px env(safe-area-inset-right) calc(4px + env(safe-area-inset-bottom)) env(safe-area-inset-left);background:var(--card);box-shadow:0 -2px 10px rgba(0,0,0,.08);}
+  .dock-btn{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;background:none;border:0;padding:6px 0;font-size:10px;line-height:1;color:var(--ink);}
+  .dock-btn span{width:24px;height:24px;margin-bottom:2px;background:currentColor;mask-repeat:no-repeat;mask-position:center;mask-size:contain;}
+  .dock-home span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 12l9-9 9 9v9h-6v-6h-6v6H3z"/></svg>');}
+  .dock-quote span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M6.6 10.8a15 15 0 0 0 6.6 6.6l2.2-2.2a1 1 0 0 1 1.1-.2 11.4 11.4 0 0 0 3.5 1.6 1 1 0 0 1 1 1v3.5a1 1 0 0 1-1 1A17.5 17.5 0 0 1 2 6a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .6 3.5 1 1 0 0 1-.2 1.1z"/></svg>');}
+  .dock-menu span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 6h18M3 12h18M3 18h18" stroke="black" stroke-width="2" stroke-linecap="round"/></svg>');}
+  .dock-btn.dock-menu{flex-basis:33%;}
+  .dock-btn.dock-quote{transform:translateY(-8px);}
+  .dock-btn em{font-style:normal;}
+
+  .neon{position:fixed;inset:0;display:none;background:rgba(0,0,0,.8);backdrop-filter:blur(12px);align-items:center;justify-content:center;}
+  .neon.is-open{display:flex;}
+  .neon__inner{background:var(--card);color:var(--ink);padding:32px;border-radius:var(--r,16px);box-shadow:0 0 0 4px hsl(var(--accent-hue) 90% 60% / .8);max-height:90vh;overflow:auto;min-width:min(90vw,400px);position:relative;}
+  .neon__nav a{display:block;padding:8px 0;color:inherit;text-decoration:none;}
+  .neon__close{position:absolute;top:16px;right:16px;background:none;border:0;font-size:32px;line-height:1;color:inherit;}
+
+  :root[data-theme="ebook"] body{background:var(--bg);color:var(--ink);}
+  :root[data-theme="ebook"] .content{max-width:68ch;margin-inline:auto;line-height:1.75;}
+  :root[data-theme="ebook"] p,
+  :root[data-theme="ebook"] li{text-align:justify;}
+}
+
+@layer utilities {
+  .offer-reveal.is-on .card{will-change:transform;}
+  .is-hidden{display:none!important;}
 }

--- a/assets/js/kras-ui.js
+++ b/assets/js/kras-ui.js
@@ -1,80 +1,65 @@
 (function(){
   const doc = document.documentElement;
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const rIC = window.requestIdleCallback || function(cb){ setTimeout(cb,1); };
 
-  /* Theme */
-  const themeBtn = document.getElementById('theme-toggle');
-  const themes = ['system','dark','light','ebook'];
-  let current = localStorage.getItem('kras-theme') || 'system';
-  const hint = document.createElement('div');
-  hint.className = 'theme-hint';
-  hint.hidden = true;
-  themeBtn && themeBtn.after(hint);
-
-  function applyTheme(t){
-    doc.removeAttribute('data-theme');
-    if(t !== 'system') doc.setAttribute('data-theme', t);
-    themeBtn && themeBtn.setAttribute('aria-pressed', t !== 'system');
-  }
-  applyTheme(current);
-
-  function recommend(){
-    const h = new Date().getHours();
-    if(h >= 20 || h < 6) return "{{ strings.theme_hint_dark }}";
-    if(current === 'ebook') return "{{ strings.theme_hint_ebook }}";
-    return "{{ strings.theme_hint_light }}";
-  }
-  function showHint(){
-    hint.textContent = recommend();
-    hint.hidden = false;
-    hint.classList.add('show');
-    setTimeout(()=>{hint.classList.remove('show');hint.hidden=true;},3000);
-  }
-  themeBtn && themeBtn.addEventListener('click', ()=>{
-    let i = (themes.indexOf(current)+1) % themes.length;
-    current = themes[i];
-    localStorage.setItem('kras-theme', current);
-    applyTheme(current);
-    showHint();
-  });
-
-  /* How it works bubble */
-  const howto = document.querySelector('.howto');
-  function showHowTo(){
-    if(!howto) return;
-    const items = howto.querySelectorAll('li');
-    howto.hidden = false;
-    items.forEach(li=>li.hidden=true);
-    if(reduce){ items.forEach(li=>li.hidden=false); return; }
-    let i=0; const step=()=>{ if(i<items.length){ items[i].hidden=false; i++; setTimeout(step,800); } };
-    step();
+  function initTheme(){
+    const btn = document.getElementById('theme-toggle');
+    if(!btn) return;
+    const themes = ['system','dark','light','ebook'];
+    let current = localStorage.getItem('kras-theme') || 'system';
+    const hint = document.createElement('span');
+    hint.className = 'theme-hint';
+    hint.hidden = true;
+    btn.after(hint);
+    function apply(t){
+      doc.removeAttribute('data-theme');
+      if(t !== 'system') doc.setAttribute('data-theme', t);
+      btn.setAttribute('aria-pressed', t !== 'system');
+    }
+    function showHint(txt){
+      if(!txt) return;
+      hint.textContent = txt;
+      hint.hidden = false;
+      requestAnimationFrame(()=>hint.classList.add('show'));
+      setTimeout(()=>{hint.classList.remove('show');hint.hidden=true;},3000);
+    }
+    apply(current);
+    btn.addEventListener('click', ()=>{
+      current = themes[(themes.indexOf(current)+1)%themes.length];
+      localStorage.setItem('kras-theme', current);
+      apply(current);
+      const hints = (window.KRAS_STRINGS && window.KRAS_STRINGS.theme_hints) || {};
+      showHint(hints[current]);
+    });
   }
 
-  /* Bottom dock */
-  const dockCTA = document.querySelector('.bottom-dock .cta');
-  const dockMenu = document.querySelector('.bottom-dock .menu');
-  dockCTA && dockCTA.addEventListener('click', e=>{
-    const t = document.getElementById('kontakt');
-    t && t.scrollIntoView({behavior:'smooth'});
-    showHowTo();
-  });
-  dockMenu && dockMenu.addEventListener('click', ()=>{ openMenu(); });
+  function gateAnimations(){
+    if(reduce) return;
+    rIC(()=>doc.classList.remove('no-motion'));
+  }
 
-  /* Neon menu */
-  const neon = document.getElementById('neon-menu');
-  const neonNav = neon ? neon.querySelector('.neon-nav') : null;
-  const closeBtn = neon ? neon.querySelector('.neon-close') : null;
-  let lastFocus = null;
+  function initDock(){
+    const quote = document.querySelector('.dock-quote');
+    const menuBtn = document.getElementById('dock-menu');
+    quote && quote.addEventListener('click', e=>{
+      const t = document.getElementById('kontakt');
+      t && t.scrollIntoView({behavior:'smooth'});
+      showHowTo();
+    });
+    menuBtn && menuBtn.addEventListener('click', openMenu);
+  }
 
+  let neon, lastFocus;
   function buildMenu(){
-    if(!neonNav) return;
+    const nav = neon.querySelector('.neon__nav');
+    nav.innerHTML = '';
     const src = document.getElementById('site-nav');
     if(src && src.children.length){
-      neonNav.innerHTML = src.innerHTML;
-    } else if(window.KRAS_NAV){
-      neonNav.innerHTML = '';
+      nav.innerHTML = src.innerHTML;
+    }else if(window.KRAS_NAV && window.KRAS_NAV.items){
       const ul = document.createElement('ul');
-      (window.KRAS_NAV.items||[]).forEach(it=>{
+      window.KRAS_NAV.items.forEach(it=>{
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = it.href;
@@ -82,68 +67,153 @@
         li.appendChild(a);
         ul.appendChild(li);
       });
-      neonNav.appendChild(ul);
+      nav.appendChild(ul);
+    }
+    const langs = neon.querySelector('.neon__langs');
+    if(langs){
+      langs.innerHTML = '';
+      const langData = (window.KRAS_NAV && window.KRAS_NAV.langs) || [];
+      langData.forEach(l=>{
+        const a = document.createElement('a');
+        a.href = l.href;
+        a.innerHTML = `<img src="${l.flag}" alt="" width="16" height="12"> ${l.label}`;
+        langs.appendChild(a);
+      });
     }
   }
-
+  function trap(e){
+    if(e.key === 'Escape'){ closeMenu(); return; }
+    if(e.key !== 'Tab') return;
+    const focusables = neon.querySelectorAll('a,button');
+    if(!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length-1];
+    if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
+    else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+  }
   function openMenu(){
     if(!neon) return;
     buildMenu();
     neon.hidden = false;
     neon.classList.add('is-open');
     lastFocus = document.activeElement;
-    doc.addEventListener('keydown', trap);
+    document.addEventListener('keydown', trap);
     const f = neon.querySelector('a,button');
     f && f.focus();
   }
-
   function closeMenu(){
     if(!neon) return;
     neon.classList.remove('is-open');
     neon.hidden = true;
-    doc.removeEventListener('keydown', trap);
+    document.removeEventListener('keydown', trap);
     lastFocus && lastFocus.focus();
   }
-
-  function trap(e){
-    if(e.key === 'Escape') closeMenu();
+  function initNeonMenu(){
+    neon = document.getElementById('neon-menu');
+    if(!neon) return;
+    neon.addEventListener('click', e=>{ if(e.target === neon) closeMenu(); });
+    const closeBtn = neon.querySelector('.neon__close');
+    closeBtn && closeBtn.addEventListener('click', closeMenu);
   }
 
-  neon && neon.addEventListener('click', e=>{ if(e.target === neon) closeMenu(); });
-  closeBtn && closeBtn.addEventListener('click', closeMenu);
-
-  /* Offer reveal */
-  const offer = document.querySelector('.offer-reveal');
-  if(offer){
-    const io = new IntersectionObserver(entries=>{
-      const ent = entries[0];
-      if(ent.isIntersecting && ent.intersectionRatio > 0.4){
-        offer.classList.add('is-on');
+  function offerReveal(){
+    const el = document.querySelector('.offer-reveal');
+    if(!el) return;
+    const io = new IntersectionObserver(([ent])=>{
+      if(ent.isIntersecting && ent.intersectionRatio>0.4){
+        el.classList.add('is-on');
         io.disconnect();
       }
     },{threshold:0.4});
-    io.observe(offer);
+    io.observe(el);
   }
 
-  /* Equalize cards */
-  function equalize(){
-    document.querySelectorAll('.cards[data-equalize]').forEach(set=>{
-      const rows = {};
-      set.querySelectorAll('.card').forEach(card=>{
-        const top = card.offsetTop;
-        const pad = card.querySelector('.pad');
-        if(!pad) return;
-        rows[top] = Math.max(rows[top]||0, pad.offsetHeight);
-      });
-      set.querySelectorAll('.card').forEach(card=>{
-        const top = card.offsetTop;
-        const pad = card.querySelector('.pad');
-        pad.style.minHeight = rows[top] + 'px';
+  function equalizeCards(){
+    const sets = document.querySelectorAll('.cards[data-equalize]');
+    if(!sets.length) return;
+    const ro = new ResizeObserver(entries=>{
+      entries.forEach(entry=>{
+        const wrap = entry.target;
+        if(window.matchMedia('(max-width:599px)').matches){
+          wrap.querySelectorAll('.card > .pad').forEach(p=>p.style.minHeight='');
+          return;
+        }
+        const pads = [...wrap.querySelectorAll('.card > .pad')];
+        let max=0,min=Infinity;
+        pads.forEach(p=>{const h=p.offsetHeight;max=Math.max(max,h);min=Math.min(min,h);});
+        if(max-min>8){pads.forEach(p=>p.style.minHeight=max+'px');}
+        else{pads.forEach(p=>p.style.minHeight='');}
       });
     });
+    sets.forEach(set=>ro.observe(set));
   }
-  const ro = new ResizeObserver(equalize);
-  document.querySelectorAll('.cards[data-equalize]').forEach(el=>ro.observe(el));
+
+  let hideHowto;
+  function showHowTo(){
+    const box = document.getElementById('howto');
+    if(!box || !box.hidden) return;
+    box.hidden = false;
+    const steps = box.querySelectorAll('li');
+    steps.forEach(li=>li.hidden=true);
+    let i=0; function step(){ if(i<steps.length){ steps[i].hidden=false; i++; setTimeout(step,800); } }
+    step();
+    function close(){ box.hidden=true; document.removeEventListener('keydown', esc); box.removeEventListener('click', close); clearTimeout(hideHowto); }
+    function esc(e){ if(e.key==='Escape') close(); }
+    document.addEventListener('keydown', esc);
+    box.addEventListener('click', close);
+    hideHowto = setTimeout(close,6000);
+  }
+  function initHowTo(){
+    const cta = document.querySelector('.hero-cta .btn.primary');
+    cta && cta.addEventListener('click', ()=>{ showHowTo(); });
+  }
+
+  function lazyBackgrounds(){
+    const canvas = document.getElementById('bg-canvas');
+    if(!canvas || reduce) return;
+    rIC(()=>{
+      canvas.hidden = false;
+      const ctx = canvas.getContext('2d');
+      let w=0,h=0,rafId,last=0;
+      function resize(){ w=canvas.width=window.innerWidth; h=canvas.height=window.innerHeight; }
+      resize(); window.addEventListener('resize', resize);
+      const sticks = Array.from({length:30},()=>({x:Math.random()*w,y:Math.random()*h,l:20+Math.random()*40,vx:(Math.random()-.5)*0.3,vy:(Math.random()-.5)*0.3}));
+      function draw(ts){
+        if(document.hidden){ rafId=requestAnimationFrame(draw); return; }
+        if(ts-last<33){ rafId=requestAnimationFrame(draw); return; }
+        last=ts;
+        ctx.clearRect(0,0,w,h);
+        ctx.strokeStyle='rgba(255,145,64,.15)';
+        sticks.forEach(s=>{
+          s.x+=s.vx; s.y+=s.vy;
+          if(s.x<0||s.x>w) s.vx*=-1;
+          if(s.y<0||s.y>h) s.vy*=-1;
+          ctx.beginPath();
+          ctx.moveTo(s.x, s.y);
+          ctx.lineTo(s.x+s.l*s.vx*5, s.y+s.l*s.vy*5);
+          ctx.stroke();
+        });
+        rafId=requestAnimationFrame(draw);
+      }
+      rafId=requestAnimationFrame(draw);
+      document.addEventListener('visibilitychange',()=>{ if(document.hidden) cancelAnimationFrame(rafId); else rafId=requestAnimationFrame(draw); });
+    });
+  }
+
+  function init(){
+    initTheme();
+    initDock();
+    initNeonMenu();
+    offerReveal();
+    equalizeCards();
+    initHowTo();
+    lazyBackgrounds();
+    gateAnimations();
+    const hero = document.getElementById('hero');
+    hero && hero.classList.add('is-ready');
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
 
   window.KRASUI = { openMenu, closeMenu, showHowTo };
 })();

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,135 +1,172 @@
 <!doctype html>
-<html lang="{{ page.lang }}">
+<html lang="{{ page.lang or 'pl' }}" class="no-motion">
 <head>
-  {% set _lang = (page.lang or DEFAULT_LANG)|lower %}
-  {% set _slug = page.slug or '' %}
-  {% set _base = site_url or SITE_URL or '' %}
-  {% set _canon = _base ~ '/' ~ _lang ~ '/' ~ (_slug ~ ('/' if _slug)) %}
+  {% set _slug = page.slugKey or page.slug or 'home' %}
+  {% set _lang = page.lang or 'pl' %}
+  {% set _canon = '/' ~ _lang ~ '/' ~ (_slug ~ '/' if _slug else '') %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>{{ page.seo_title }}</title>
-  <meta name="description" content="{{ page.meta_desc }}">
-  <link rel="canonical" href="{{ _canon }}">
+  <meta name="theme-color" content="#ff7a1a">
+  <title>{{ page.seo_title or page.title or 'Kras-Trans' }}</title>
+  <meta name="description" content="{{ page.meta_desc or page.lead or '' }}">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ page.seo_title }}">
-  <meta property="og:description" content="{{ page.meta_desc }}">
+  <meta property="og:title" content="{{ page.og_title or page.seo_title or page.title }}">
+  <meta property="og:description" content="{{ page.og_desc or page.meta_desc or page.lead }}">
+  <meta property="og:image" content="{{ page.og_image or '/assets/media/og-default.jpg' }}">
   <meta property="og:url" content="{{ _canon }}">
-  <meta property="og:image" content="{{ page.og_image }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page.seo_title or page.title }}">
+  <meta name="twitter:description" content="{{ page.meta_desc or page.lead }}">
+  <meta name="twitter:image" content="{{ page.og_image or '/assets/media/og-default.jpg' }}">
+  <link rel="canonical" href="{{ _canon }}">
+  {% if pages %}
+    {% for p in pages if (p.slugKey or p.slug) == _slug %}
+      <link rel="alternate" hreflang="{{ p.lang }}" href="/{{ p.lang }}/{{ p.slug or '' }}/">
+    {% endfor %}
+  {% endif %}
+  <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin media="(min-width:768px)">
   <link rel="stylesheet" href="/assets/css/kras-global.css">
   <link rel="stylesheet" href="/assets/css/kras-ui.css">
+  <style>.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0}</style>
 </head>
-<body>
-  <div id="bg-grid" aria-hidden="true"></div>
-  <canvas id="bg-canvas" aria-hidden="true"></canvas>
 
+<body>
+  <!-- Tła: siatka + patyczki (canvas) — domyślnie hidden; JS włączy po idle -->
+  <div id="bg-grid" aria-hidden="true"></div>
+  <canvas id="bg-canvas" aria-hidden="true" hidden></canvas>
+
+  <!-- HEADER (sticky, przezroczysty, backdrop) -->
   <header class="site-header">
-    <a class="brand" href="/{{ _lang }}/">{{ strings.brand }}</a>
-    <nav id="site-nav" class="nav" hidden></nav>
-    <div class="header-actions">
-      <button id="theme-toggle" type="button" aria-label="{{ strings.theme_toggle }}" aria-pressed="false"></button>
-      <a class="btn primary" href="#kontakt">{{ strings.cta_phone }}</a>
+    <div class="container header-grid">
+      <a class="brand" href="/">
+        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high">
+      </a>
+
+      <nav id="site-nav" class="nav" hidden aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+
+      <div class="header-actions">
+        <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="{{ strings.theme_toggle or 'Zmień motyw' }}">
+          <span class="sun"></span><span class="moon"></span><span class="paper"></span>
+        </button>
+        <a class="btn primary btn--shine" href="#kontakt">{{ strings.cta_call or 'Wyceń' }}</a>
+      </div>
     </div>
+
+    <!-- MEGA-MENU (desktop; nad hero; zasilane przez menu-builder.js) -->
+    <div id="mega-root" class="mega" hidden></div>
   </header>
 
-  <section class="hero" id="hero">
-    <div class="hero-wrap">
-      <div class="hero-copy">
-        <h1>{{ page.h1 }}</h1>
-        {% if page.lead %}<p class="lead">{{ page.lead }}</p>{% endif %}
-        <div class="hero-buttons">
-          <a class="btn primary" href="#kontakt">{{ strings.cta_hero }}</a>
-          <div class="howto" hidden aria-live="polite">
+  <main id="main" class="content" role="main">
+    <!-- HERO (21:9, bez stałego tła) -->
+    <section class="hero" id="hero">
+      <div class="container hero-wrap">
+        <div class="hero-copy">
+          <span class="claim">{{ page.claim or 'Kompleksowe usługi transportowe' }}</span>
+          <h1>{{ page.h1 or page.title }}</h1>
+          {% if page.lead %}<p class="lead">{{ page.lead }}</p>{% endif %}
+          <p class="hero-cta">
+            <a class="btn primary" href="#kontakt">{{ strings.hero_cta_primary or 'Wyceń transport teraz' }}</a>
+            <a class="btn" href="tel:{{ (company and company[0].telephone) or '+48793927467' }}">{{ strings.hero_cta_secondary or 'Zadzwoń' }}</a>
+          </p>
+          <!-- Dymek: Jak to działa -->
+          <aside class="howto" id="howto" hidden aria-live="polite">
             <ol>
-              <li>{{ strings.how1 }}</li>
-              <li>{{ strings.how2 }}</li>
-              <li>{{ strings.how3 }}</li>
+              <li>Kliknij „Wyceń transport teraz”.</li>
+              <li>Wpisz trasę i dane ładunku.</li>
+              <li>Wyślij – oddzwonimy i potwierdzimy odbiór.</li>
             </ol>
-          </div>
+          </aside>
         </div>
-      </div>
-      <div class="hero-media">
         {% if page.hero_video %}
-        <video src="{{ page.hero_video }}" poster="{{ page.hero_image }}" aria-label="{{ page.hero_alt }}" playsinline muted loop></video>
+          <video class="hero-media" muted loop playsinline preload="none" poster="{{ page.hero_poster or '' }}" width="1680" height="720">
+            <source src="{{ page.hero_video or '/assets/media/hero.mp4' }}" type="video/mp4">
+          </video>
         {% elif page.hero_image %}
-        <img src="{{ page.hero_image }}" alt="{{ page.hero_alt }}">
+          <img class="hero-media" src="{{ page.hero_image }}" alt="{{ page.hero_alt or page.h1 }}" width="1680" height="720" loading="eager" fetchpriority="high">
         {% endif %}
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="section offer-reveal" id="oferta">
-    <div class="offer-stage">
-      <h2 class="offer-heading">{{ strings.offers_title }}</h2>
-      <div class="cards cards--scroll" data-equalize>
-        {% for it in offers %}
-        <article class="card offer">
-          {% if it.image %}<img src="{{ it.image }}" alt="{{ it.alt }}">{% endif %}
-          <div class="pad">
-            <h3>{{ it.h1 or it.title }}</h3>
-            {% if it.lead %}<p>{{ it.lead }}</p>{% endif %}
-            <a class="btn small" href="{{ it.href }}">{{ strings.more }}</a>
-          </div>
-        </article>
-        {% endfor %}
+    <!-- OFERTA (H2→kafelki w tej samej przestrzeni) -->
+    <section class="section offer-reveal" id="oferta" data-section="offers" data-style="edge" data-accent="amber">
+      <div class="container offer-stage">
+        <h2 class="offer-heading">{{ strings.offers_title or 'Nasza oferta' }}</h2>
+
+        {% set offers = (blocks or [])|selectattr('block','equalto','offer')|selectattr('lang','equalto',(page.lang or 'pl'))|selectattr('page','equalto',(page.slugKey or page.slug or 'home'))|list %}
+        {% if not offers|length %}{% set offers = (pages or [])|selectattr('type','equalto','service')|selectattr('lang','equalto',(page.lang or 'pl'))|list %}{% endif %}
+
+        {% if offers|length %}
+        <div class="cards cards--wrap cards--scroll tilt-cards" data-equalize="true" aria-label="{{ strings.offers_list or 'Usługi (przesuń w bok na telefonie)' }}">
+          {% for it in offers|sort(attribute='order') %}
+          {% set url = it.href or it.url or '/' ~ (page.lang or 'pl') ~ '/' ~ (it.slug or '') ~ '/' %}
+          <article class="card offer">
+            {% if it.media %}<img class="card-img" src="{{ it.media }}" alt="">{% endif %}
+            <div class="pad">
+              <h3>{{ it.h1 or it.title or it.seo_title or it.slug }}</h3>
+              {% if it.lead or it.desc or it.meta_desc %}<p class="desc">{{ it.lead or it.desc or it.meta_desc }}</p>{% endif %}
+              <a class="btn" href="{{ url }}">{{ it.cta or strings.read_more or 'Szczegóły' }}</a>
+            </div>
+          </article>
+          {% endfor %}
+        </div>
+        {% endif %}
       </div>
+      <div class="sep sep--morph" data-morph="wave-2" aria-hidden="true"></div>
+    </section>
+
+    <!-- KIERUNKI (Twoja mapa) -->
+    <section class="section" id="kierunki" data-section="kierunki" data-style="glass">
+      <div class="container text"><h2>{{ strings.routes_title or 'Kierunki' }}</h2></div>
+      <div class="container">
+        <div class="iframe-wrap" style="aspect-ratio:16/9">
+          <iframe class="routes-map" title="Mapa kierunków"
+                  loading="lazy"
+                  src="/assets/media/mapa-kierunkow-kras-trans.html"
+                  sandbox="allow-scripts allow-same-origin"
+                  referrerpolicy="no-referrer"></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ / BLOG / CTA / KONTAKT – puste sloty jak w globalnym szablonie -->
+    <!-- … (zostaw analogiczne sekcje: faq, blog, contact – placeholders) … -->
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" width="120" height="28" alt="Kras-Trans" loading="lazy">
+        <div class="company">
+          <strong>{{ company[0].name or 'Kras-Trans' }}</strong><br>
+          {% if company and company[0].streetAddress %}{{ company[0].streetAddress }}{% endif %}
+          {% if company and company[0].postalCode %}, {{ company[0].postalCode }}{% endif %}
+          {% if company and company[0].addressLocality %} {{ company[0].addressLocality }}{% endif %}<br>
+          <a href="tel:{{ (company and company[0].telephone) or '+48793927467' }}">{{ (company and company[0].telephone) or '+48 793 927 467' }}</a>
+        </div>
+      </div>
+      <nav class="footer-links" aria-label="{{ strings.nav_footer or 'Nawigacja w stopce' }}"></nav>
     </div>
-  </section>
-
-  <section id="faq">
-    {% for f in page_faq %}
-    <details>
-      <summary>{{ f.question }}</summary>
-      <div>{{ f.answer }}</div>
-    </details>
-    {% endfor %}
-  </section>
-
-  <section id="kontakt">
-    <form id="contact-form">
-      <input name="name" placeholder="{{ strings.form_name }}">
-      <button class="btn btn--progress" type="submit">{{ strings.form_send }}</button>
-    </form>
-  </section>
-
-  <footer>
-    <div class="foot-wrap">
-      <div class="foot-col">{{ company[0].name }}</div>
-      <div class="foot-col">{{ company[0].streetAddress }}</div>
-    </div>
+    <div class="container"><small>© {{ (now or '')[:4] or '' }} {{ company[0].name or 'Kras-Trans' }}</small></div>
   </footer>
 
-  <nav class="bottom-dock" role="navigation" aria-label="{{ strings.nav_mobile }}">
-    <a class="dock-item home" href="/{{ _lang }}/" aria-label="{{ strings.nav_home }}">
-      <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M3 12l9-9 9 9v9h-6v-6h-6v6H3z"/></svg>
-    </a>
-    <a class="dock-item cta" href="#kontakt" aria-label="{{ strings.nav_quote }}">
-      <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M6.6 10.8a15 15 0 006.6 6.6l2.2-2.2a1 1 0 011.1-.2 11.4 11.4 0 003.5.6 1 1 0 011 1v3.5a1 1 0 01-1 1A17.5 17.5 0 012 6a1 1 0 011-1h3.5a1 1 0 011 1 11.4 11.4 0 00.6 3.5 1 1 0 01-.2 1.1z"/></svg>
-    </a>
-    <button class="dock-item menu" type="button" aria-label="{{ strings.nav_menu }}" aria-pressed="false">
-      <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
-    </button>
+  <!-- MOBILE DOCK -->
+  <nav class="bottom-dock" aria-label="Szybka nawigacja">
+    <a class="dock-btn dock-home" href="/{{ (page.lang or 'pl') }}/" aria-label="{{ strings.home or 'Start' }}"><span></span><em>Start</em></a>
+    <a class="dock-btn dock-quote" href="#kontakt" aria-label="{{ strings.quote or 'Wyceń' }}"><span></span><em>Wyceń</em></a>
+    <button class="dock-btn dock-menu" id="dock-menu" aria-label="{{ strings.menu or 'Menu' }}"><span></span><em>Menu</em></button>
   </nav>
 
-  <div id="neon-menu" class="neon" hidden>
-    <div class="neon-wrap" tabindex="-1">
-      <button class="neon-close" type="button" aria-label="{{ strings.nav_close }}"></button>
-      <nav class="neon-nav"></nav>
+  <!-- NEON MENU (fullscreen) -->
+  <div id="neon-menu" class="neon" hidden aria-modal="true" role="dialog">
+    <div class="neon__inner">
+      <button class="neon__close" aria-label="{{ strings.close or 'Zamknij' }}">×</button>
+      <nav class="neon__nav" aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+      <div class="neon__langs" aria-label="{{ strings.nav_langs or 'Języki' }}"></div>
     </div>
   </div>
 
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@graph":[
-      {"@type":"Organization","name":"{{ company[0].name }}","telephone":"{{ company[0].telephone }}","address":{"@type":"PostalAddress","streetAddress":"{{ company[0].streetAddress }}"}},
-      {"@type":"WebPage","name":"{{ page.seo_title }}","url":"{{ _canon }}"},
-      {"@type":"BreadcrumbList","itemListElement":[]}
-      {% if page_faq|length %},
-      {"@type":"FAQPage","mainEntity":[{% for f in page_faq %}{"@type":"Question","name":"{{ f.question }}","acceptedAnswer":{"@type":"Answer","text":"{{ f.answer }}"}}{% if not loop.last %},{% endif %}{% endfor %}]}
-      {% endif %}
-    ]
-  }
-  </script>
+  <!-- SKRYPTY -->
   <script src="/assets/js/kras-global.js" defer></script>
   <script src="/assets/js/menu-builder.js" defer></script>
   <script src="/assets/js/kras-ui.js" defer></script>


### PR DESCRIPTION
## Summary
- add ultra-light `page.html` template with placeholders, hero, offers, dock and neon menu
- introduce scoped UI layer `kras-ui.css` for themes, cards, docks and ebook mode
- implement zero-dependency `kras-ui.js` for theme cycling, menu, animations and helpers

## Testing
- `python tools/build_local.py` *(fails: Missing APPS_URL or APPS_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1b7037083339201e0707dd16ea0