### PR TITLE
Fix srcset generation for webp variants

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -230,7 +230,7 @@ def rewrite_img_srcset(tag, doc_lang: str):
         # posortuj rosnąco po szerokości
         variants.sort(key=lambda x: x[0])
         srcset = ", ".join([
-            f"/assets/media/responsive/{v[1].name} {w}w" for (w, v) in variants
+            f"/assets/media/responsive/{v.name} {w}w" for (w, v) in variants
         ])
         tag["srcset"] = srcset
         # sizes heurystyka


### PR DESCRIPTION
## Summary
- fix srcset builder to use Path.name instead of subscripting
- tidy indentation in WEBP srcset block

## Testing
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_689fa6288da8833383108c7f5968c567