### PR TITLE
Fix smoke test by supplying CMS data

### DIFF
--- a/data/cms.json
+++ b/data/cms.json
@@ -1,32 +1,39 @@
 {
   "pages": [
     {
-      "lang": "pl",
       "slug": "",
       "slugKey": "home",
+      "lang": "pl",
       "title": "Kras-Trans — Transport ekspresowy",
-      "meta_desc": "Profesjonalny transport ekspresowy.",
-      "page_html": "<p>Witamy na stronie Kras-Trans</p>"
+      "seo_title": "Kras-Trans — Transport ekspresowy",
+      "meta_desc": "Szybki i niezawodny transport ekspresowy dla firm i klientów indywidualnych w całej Europie. Sprawdź naszą ofertę.",
+      "page_html": "<h1>Witamy w Kras-Trans</h1><p>Transport ekspresowy</p>"
     }
   ],
+  "strings": [],
   "company": [
     {
       "name": "Kras-Trans",
-      "telephone": "+48 123 456 789"
+      "street_address": "Example St 1",
+      "city": "Warszawa",
+      "region": "",
+      "postal_code": "00-001",
+      "country": "PL",
+      "telephone": "+48 000 000 000",
+      "email": "info@kras-trans.com"
     }
   ],
-  "nav": [],
-  "strings": [],
   "faq": [],
   "media": [],
-  "redirects": [],
   "blocks": [],
   "routes": [],
   "places": [],
   "blog": [],
   "reviews": [],
+  "jobs": [],
   "authors": [],
   "categories": [],
-  "jobs": [],
-  "autolinks": []
+  "autolinks": [],
+  "nav": [],
+  "redirects": []
 }

--- a/templates/page.html
+++ b/templates/page.html
@@ -38,7 +38,7 @@
   <!-- HEADER (sticky, przezroczysty, backdrop) -->
   <header class="site-header">
     <div class="container header-grid">
-      <a class="brand" href="/">
+      <a class="brand" href="/{{ page.lang or 'pl' }}/">
         <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high">
       </a>
 


### PR DESCRIPTION
## Summary
- provide minimal CMS JSON with home page and company data
- link brand logo to language root

## Testing
- `python tools/build.py`
- `find dist -maxdepth 2 -type f | sort`


------
https://chatgpt.com/codex/tasks/task_e_689faa5e41f083339650d792c869fa36