### PR TITLE
Fail build on CMS errors

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -89,7 +89,13 @@ def fail(path: str, msg: str):
 if not DATA.exists():
     raise SystemExit("Brak data/cms.json (sprawdź krok 'Fetch CMS JSON').")
 
-CMS = json.loads(DATA.read_text(encoding="utf-8"))
+try:
+    CMS = json.loads(DATA.read_text(encoding="utf-8"))
+except json.JSONDecodeError as e:
+    raise SystemExit(f"Błędny JSON z CMS: {e}")
+
+if isinstance(CMS, dict) and not CMS.get("ok", True):
+    raise SystemExit(f"Błąd CMS: {CMS.get('error', 'unknown')}")
 
 PAGES      = CMS.get("pages", []) or []
 FAQ        = CMS.get("faq", []) or []

--- a/tools/build_local.py
+++ b/tools/build_local.py
@@ -27,7 +27,12 @@ def fetch_data():
     url = f"{APPS_URL}?key={APPS_KEY}"
     r = requests.get(url, timeout=30)
     r.raise_for_status()
-    return r.json()
+    data = r.json()
+    if not isinstance(data, dict):
+        raise SystemExit("Invalid CMS JSON")
+    if not data.get("ok", True):
+        raise SystemExit(f"CMS error: {data.get('error', 'unknown')}")
+    return data
 
 def words(t: str):
     return set(re.findall(r"[a-z0-9ąćęłńóśżź\-]+", (t or "").lower()))


### PR DESCRIPTION
## Summary
- Abort build when CMS JSON contains an error flag
- Validate CMS data in local builder to surface authorization issues

## Testing
- `python tools/build.py`
- `python tools.build.py` with invalid `cms.json`

------
https://chatgpt.com/codex/tasks/task_e_689fadebe2908333b7d878d47e4374c5