### PR TITLE
feat: add ultra-light static template and UI

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -83,8 +83,7 @@
   .dock-home span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 12l9-9 9 9v9h-6v-6h-6v6H3z"/></svg>');}
   .dock-quote span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M6.6 10.8a15 15 0 0 0 6.6 6.6l2.2-2.2a1 1 0 0 1 1.1-.2 11.4 11.4 0 0 0 3.5 1.6 1 1 0 0 1 1 1v3.5a1 1 0 0 1-1 1A17.5 17.5 0 0 1 2 6a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .6 3.5 1 1 0 0 1-.2 1.1z"/></svg>');}
   .dock-menu span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 6h18M3 12h18M3 18h18" stroke="black" stroke-width="2" stroke-linecap="round"/></svg>');}
-  .dock-btn.dock-menu{flex-basis:33%;}
-  .dock-btn.dock-quote{transform:translateY(-8px);}
+  .dock-btn.dock-quote{flex:1.4;transform:translateY(-8px);}
   .dock-btn em{font-style:normal;}
 
   .neon{position:fixed;inset:0;display:none;background:rgba(0,0,0,.8);backdrop-filter:blur(12px);align-items:center;justify-content:center;}

--- a/assets/js/kras-ui.js
+++ b/assets/js/kras-ui.js
@@ -1,4 +1,5 @@
 (function(){
+  'use strict';
   const doc = document.documentElement;
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const rIC = window.requestIdleCallback || function(cb){ setTimeout(cb,1); };

--- a/templates/page.html
+++ b/templates/page.html
@@ -38,7 +38,7 @@
   <!-- HEADER (sticky, przezroczysty, backdrop) -->
   <header class="site-header">
     <div class="container header-grid">
-      <a class="brand" href="/{{ page.lang or 'pl' }}/">
+      <a class="brand" href="/">
         <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high">
       </a>
 


### PR DESCRIPTION
## Summary
- add static Jinja page template with hero, offers, map, and mobile dock
- style components and tokens for themes, cards, dock, and neon menu
- implement vanilla JS for theme cycle, menu, animations, and helpers

## Testing
- `node --check assets/js/kras-ui.js`

------
https://chatgpt.com/codex/tasks/task_e_689fba225b748333b9aa01478ed63d38