### PR TITLE
feat: add split hero offers section

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -39,6 +39,7 @@
   @media (prefers-reduced-motion:reduce){
     html.no-motion{ }
   }
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 }
 
 @layer components {
@@ -57,12 +58,6 @@
   .hero-media{width:100%;height:auto;opacity:0;transition:opacity .6s ease;}
   .hero.is-ready .hero-media{opacity:1;}
 
-  .offer-stage{min-height:clamp(32rem,60vh,48rem);position:relative;}
-  .offer-heading{display:inline-block;transform:scaleX(0);transform-origin:left;mask:linear-gradient(90deg,#000 60%,transparent);transition:transform .6s ease;}
-  .offer-reveal .cards{opacity:0;transform:translateY(40px);transition:opacity .6s ease,transform .6s ease;}
-  .offer-reveal.is-on .offer-heading{transform:scaleX(1);}
-  .offer-reveal.is-on .cards{opacity:1;transform:none;}
-
   .cards{display:grid;gap:clamp(16px,3vw,32px);}
   .cards--wrap{grid-auto-flow:column;}
   .cards--scroll{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;}
@@ -76,6 +71,37 @@
   .tilt-cards{perspective:1000px;}
   .tilt-cards .card{transform-style:preserve-3d;}
   .tilt-cards .card:is(:hover,:focus-within){transform:translateY(-4px) rotateX(1.5deg) rotateY(-1.5deg);}
+
+  /* Split Hero (napis -> rail w tym samym miejscu) */
+  .split-hero{ position:relative; height:140vh; }
+  .split-hero__sticky{ position:sticky; top:calc(54px + 1svh); display:grid; place-items:center; padding-block:clamp(18px,4vh,32px); min-height:clamp(340px,58vh,680px); z-index:1; }
+  .split-hero__stack{ --stack-h:clamp(140px,14vw,220px); position:relative; width:min(var(--offer-maxw,860px),92vw); height:var(--stack-h); margin-inline:auto; container-type:inline-size; }
+  .split-hero--narrow .split-hero__stack{ --offer-maxw:860px }
+  .split-hero--wide .split-hero__stack{ --offer-maxw:1100px }
+  .split-hero__stack > *{ position:absolute; inset:0 }
+  .split-hero__title{ opacity:calc(1 - var(--p,0)); transition:opacity .2s linear }
+  .title-half{ display:grid; place-items:center; line-height:1; text-transform:uppercase; font-weight:900; font-size:clamp(36px,16cqw,96px); letter-spacing:.04em; color:var(--ink); text-shadow:0 1px 0 color-mix(in oklab, var(--ink) 10%, transparent); will-change:transform,opacity }
+  .title-left { clip-path: inset(0 50% 0 0); transform: translateX(calc(-50cqw * var(--p, 0))); }
+  .title-right{ clip-path: inset(0 0 0 50%); transform: translateX(calc( 50cqw * var(--p, 0))); }
+  .split-hero__rail{ display:grid; grid-auto-flow: column; grid-auto-columns: clamp(220px, 42cqw, 360px); gap:16px; overflow-x:auto; padding:6px; scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; align-items:stretch; height:100%; opacity: var(--p, 0); transform: translateY(calc(14px * (1 - var(--p, 0)))); transition: opacity .2s linear, transform .2s ease; pointer-events:none; }
+  .split-hero__rail > *{ scroll-snap-align:start }
+  .offer-card{ position:relative; height:100%; border-radius:18px; overflow:hidden; isolation:isolate; background:var(--card); border:1px solid color-mix(in srgb,var(--ink) 20%, transparent); box-shadow:var(--shadow-1,0 4px 18px rgba(0,0,0,.08)); }
+  .offer-card img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; transform:scale(1.02); transition:transform .35s ease }
+  .offer-card::after{ content:""; position:absolute; inset:0; background:linear-gradient(180deg,transparent,rgba(0,0,0,.35) 68%,rgba(0,0,0,.55)); mix-blend-mode:multiply; pointer-events:none }
+  .offer-card__title,.offer-card__desc{ position:absolute; left:16px; right:16px; color:#fff; z-index:1; text-shadow:0 1px 2px rgba(0,0,0,.4) }
+  .offer-card__title{ bottom:42px; font-weight:800; font-size:clamp(15px,7cqw,20px) }
+  .offer-card__desc { bottom:14px; font-size:clamp(12px,5cqw,14px); opacity:.95 }
+  @media (hover:hover){ .offer-card:hover img{ transform:scale(1.06) } }
+  @supports not (container-type: inline-size){
+    .title-left { transform: translateX(calc(-28vw * var(--p, 0))) }
+    .title-right{ transform: translateX(calc( 28vw * var(--p, 0))) }
+    .split-hero__rail{ grid-auto-columns: clamp(220px, 45vw, 360px) }
+  }
+  @media (prefers-reduced-motion: reduce){
+    .title-left,.title-right{ transform:none !important }
+    .split-hero__title{ opacity:0 !important }
+    .split-hero__rail{ opacity:1 !important; transform:none !important; pointer-events:auto !important }
+  }
 
   .bottom-dock{position:fixed;bottom:0;left:0;right:0;z-index:50;display:flex;justify-content:space-around;padding:4px env(safe-area-inset-right) calc(4px + env(safe-area-inset-bottom)) env(safe-area-inset-left);background:var(--card);box-shadow:0 -2px 10px rgba(0,0,0,.08);}
   .dock-btn{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;background:none;border:0;padding:6px 0;font-size:10px;line-height:1;color:var(--ink);}
@@ -99,6 +125,5 @@
 }
 
 @layer utilities {
-  .offer-reveal.is-on .card{will-change:transform;}
   .is-hidden{display:none!important;}
 }

--- a/assets/js/kras-ui.js
+++ b/assets/js/kras-ui.js
@@ -117,16 +117,31 @@
     closeBtn && closeBtn.addEventListener('click', closeMenu);
   }
 
-  function offerReveal(){
-    const el = document.querySelector('.offer-reveal');
-    if(!el) return;
-    const io = new IntersectionObserver(([ent])=>{
-      if(ent.isIntersecting && ent.intersectionRatio>0.4){
-        el.classList.add('is-on');
-        io.disconnect();
-      }
-    },{threshold:0.4});
-    io.observe(el);
+  function initOfferReveal(){
+    const host = document.getElementById('offer-reveal');
+    if(!host) return;
+    const sticky = host.querySelector('.split-hero__sticky');
+    const rail = host.querySelector('.split-hero__rail');
+    if(matchMedia('(prefers-reduced-motion: reduce)').matches){
+      host.style.setProperty('--p', 1);
+      if(rail) rail.style.pointerEvents='auto';
+      return;
+    }
+    const calc=()=>{
+      const r = host.getBoundingClientRect();
+      const full = (host.offsetHeight - sticky.offsetHeight) || 1;
+      const passed = Math.min(Math.max(-r.top,0), full);
+      const p = Math.min(Math.max(passed/full,0),1);
+      host.style.setProperty('--p', p.toFixed(4));
+      if(rail) rail.style.pointerEvents = p>0.15 ? 'auto' : 'none';
+    };
+    let ticking=false;
+    const onScroll=()=>{ if(ticking) return; ticking=true; requestAnimationFrame(()=>{ ticking=false; calc(); }); };
+    const io=new IntersectionObserver(e=>{
+      if(e[0].isIntersecting){ addEventListener('scroll', onScroll, {passive:true}); addEventListener('resize', onScroll); calc(); }
+      else { removeEventListener('scroll', onScroll); removeEventListener('resize', onScroll); }
+    });
+    io.observe(host);
   }
 
   function equalizeCards(){
@@ -205,7 +220,7 @@
     initTheme();
     initDock();
     initNeonMenu();
-    offerReveal();
+    initOfferReveal();
     equalizeCards();
     initHowTo();
     lazyBackgrounds();

--- a/templates/page.html
+++ b/templates/page.html
@@ -87,29 +87,32 @@
       </div>
     </section>
 
-    <!-- OFERTA (H2→kafelki w tej samej przestrzeni) -->
-    <section class="section offer-reveal" id="oferta" data-section="offers" data-style="edge" data-accent="amber">
-      <div class="container offer-stage">
-        <h2 class="offer-heading">{{ strings.offers_title or 'Nasza oferta' }}</h2>
+    <!-- OFERTA (split hero: słowo z arkuszy + kafelki w railu) -->
+    <section class="section split-hero split-hero--narrow" id="offer-reveal" data-section="offers" data-style="edge" data-accent="amber" aria-label="{{ strings.offers_aria or 'Nasza oferta' }}">
+      <div class="split-hero__sticky">
+        <div class="split-hero__stack">
+          <div class="split-hero__title" aria-hidden="true">
+            <span class="title-half title-left">{{ strings.offers_title or 'Nasza oferta' }}</span>
+            <span class="title-half title-right">{{ strings.offers_title or 'Nasza oferta' }}</span>
+          </div>
+          <h2 class="sr-only">{{ strings.offers_title or 'Nasza oferta' }}</h2>
 
-        {% set offers = (blocks or [])|selectattr('block','equalto','offer')|selectattr('lang','equalto',(page.lang or 'pl'))|selectattr('page','equalto',(page.slugKey or page.slug or 'home'))|list %}
-        {% if not offers|length %}{% set offers = (pages or [])|selectattr('type','equalto','service')|selectattr('lang','equalto',(page.lang or 'pl'))|list %}{% endif %}
+          {% set offers = (blocks or [])|selectattr('block','equalto','offer')|selectattr('lang','equalto',(page.lang or 'pl'))|selectattr('page','equalto',(page.slugKey or page.slug or 'home'))|list %}
+          {% if not offers|length %}{% set offers = (pages or [])|selectattr('type','equalto','service')|selectattr('lang','equalto',(page.lang or 'pl'))|list %}{% endif %}
 
-        {% if offers|length %}
-        <div class="cards cards--wrap cards--scroll tilt-cards" data-equalize="true" aria-label="{{ strings.offers_list or 'Usługi (przesuń w bok na telefonie)' }}">
-          {% for it in offers|sort(attribute='order') %}
-          {% set url = it.href or it.url or '/' ~ (page.lang or 'pl') ~ '/' ~ (it.slug or '') ~ '/' %}
-          <article class="card offer">
-            {% if it.media %}<img class="card-img" src="{{ it.media }}" alt="">{% endif %}
-            <div class="pad">
-              <h3>{{ it.h1 or it.title or it.seo_title or it.slug }}</h3>
-              {% if it.lead or it.desc or it.meta_desc %}<p class="desc">{{ it.lead or it.desc or it.meta_desc }}</p>{% endif %}
-              <a class="btn" href="{{ url }}">{{ it.cta or strings.read_more or 'Szczegóły' }}</a>
-            </div>
-          </article>
-          {% endfor %}
+          {% if offers|length %}
+          <div class="split-hero__rail" id="offer-rail" role="list" aria-label="{{ strings.offers_list or 'Usługi (przesuń w bok na telefonie)' }}">
+            {% for it in offers|sort(attribute='order') %}
+            {% set url = it.href or it.url or '/' ~ (page.lang or 'pl') ~ '/' ~ (it.slug or '') ~ '/' %}
+            <a role="listitem" class="offer-card" href="{{ url }}">
+              {% if it.media %}<img src="{{ it.media }}" alt="" width="{{ it.img_w or 1280 }}" height="{{ it.img_h or 720 }}" loading="lazy" decoding="async">{% endif %}
+              <span class="offer-card__title">{{ it.h1 or it.title or it.seo_title or it.slug }}</span>
+              {% if it.lead or it.desc or it.meta_desc %}<span class="offer-card__desc">{{ it.lead or it.desc or it.meta_desc }}</span>{% endif %}
+            </a>
+            {% endfor %}
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
       </div>
       <div class="sep sep--morph" data-morph="wave-2" aria-hidden="true"></div>
     </section>


### PR DESCRIPTION
## Summary
- replace offer section with split hero rail and dynamic heading from CMS
- add CSS for split hero layout and offer cards
- add JS scroll handler for reveal

## Testing
- `pip install -r requirements.txt`
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_689fc095920083339b72ecff560d8e42