### PR TITLE
Build menu from CMS navigation data

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,8 +19,9 @@
   <header class="site-header">
     <a href="/" class="brand">Kras-Trans</a>
     <nav class="nav">
-      <a href="/#oferta">Oferta</a>
-      <a href="/#kontakt">Kontakt</a>
+      {% for it in nav_cfg.items %}
+      <a href="{{ it.href }}">{{ it.label }}</a>
+      {% endfor %}
       <a href="tel:+48793927467" class="btn">Zadzwoń 24/7</a>
     </nav>
   </header>
@@ -28,5 +29,7 @@
   <footer class="site-footer" id="kontakt">
     <p>© {{ (company[0].name if company else 'Kras-Trans') }} — Ekspresowy transport 24/7</p>
   </footer>
+  <script>window.KRAS_NAV = {{ nav_cfg|tojson }};</script>
+  <script src="/assets/js/menu-builder.js" defer></script>
 </body>
 </html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -171,6 +171,7 @@
   </div>
 
   <!-- SKRYPTY -->
+  <script>window.KRAS_NAV = {{ nav_cfg|tojson }};</script>
   <script src="/assets/js/kras-global.js" defer></script>
   <script src="/assets/js/menu-builder.js" defer></script>
   <script src="/assets/js/kras-ui.js" defer></script>


### PR DESCRIPTION
## Summary
- generate menu config from CMS nav rows
- expose nav items to templates and menu-builder
- render header links from CMS data

## Testing
- `python -m py_compile tools/build.py`
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_689fcc134e3083339077f3ab411c0652