### PR TITLE
feat: load header from external partial

### DIFF
--- a/assets/header.html
+++ b/assets/header.html
@@ -1,0 +1,17 @@
+<header class="site-header" role="banner">
+  <div class="container header-grid">
+    <button id="menu-toggle" class="icon-btn menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="site-nav">
+      <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+    </button>
+    <a href="/" class="brand">Kras-Trans</a>
+    <nav id="site-nav" class="nav" aria-label="Główna nawigacja"></nav>
+    <div class="header-actions">
+      <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="Przełącz motyw">
+        <span class="sun" aria-hidden="true"></span>
+        <span class="moon" aria-hidden="true"></span>
+        <span class="paper" aria-hidden="true"></span>
+      </button>
+      <a href="tel:+48793927467" class="btn primary">Zadzwoń 24/7</a>
+    </div>
+  </div>
+</header>

--- a/assets/js/header-loader.js
+++ b/assets/js/header-loader.js
@@ -1,0 +1,11 @@
+// Dynamically load shared header
+(async function(){
+  try {
+    const res = await fetch('/assets/header.html', {credentials:'omit'});
+    if(!res.ok) return;
+    const html = await res.text();
+    document.body.insertAdjacentHTML('afterbegin', html);
+  } catch(err) {
+    console.warn('Header load failed', err);
+  }
+})();

--- a/data/nav.json
+++ b/data/nav.json
@@ -1,0 +1,28 @@
+{
+  "items": [
+    {
+      "label": "Usługi",
+      "href": "/pl/uslugi/",
+      "children": [
+        {"label": "Transport międzynarodowy 3,5t", "href": "/pl/transport-miedzynarodowy/"},
+        {"label": "Transport ekspresowy", "href": "/pl/transport-ekspresowy/"},
+        {"label": "Transport ADR 3,5t", "href": "/pl/transport-adr/"},
+        {"label": "Transport paletowy", "href": "/pl/transport-paletowy/"}
+      ]
+    },
+    {
+      "label": "Kraje",
+      "href": "/pl/kraje/",
+      "children": [
+        {"label": "Niemcy", "href": "/pl/transport-do-niemiec/"},
+        {"label": "Włochy", "href": "/pl/transport-do-wloch/"},
+        {"label": "Francja", "href": "/pl/transport-do-francji/"}
+      ]
+    },
+    {"label": "Flota", "href": "/pl/flota/"},
+    {"label": "Blog", "href": "/pl/blog/"},
+    {"label": "O nas", "href": "/pl/o-nas/"},
+    {"label": "Kontakt", "href": "/pl/kontakt/"}
+  ],
+  "langs": []
+}

--- a/index.html
+++ b/index.html
@@ -9,24 +9,6 @@
   <link rel="stylesheet" href="assets/css/kras-global.css" />
 </head>
 <body>
-  <!-- HEADER (sticky + scrollowalne menu, CTA się nie łamie) -->
-  <header class="site-header" role="banner">
-    <div class="container header-grid">
-      <button id="menu-toggle" class="icon-btn menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="site-nav">
-        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
-      </button>
-      <a href="/" class="brand">Kras-Trans</a>
-      <nav id="site-nav" class="nav" aria-label="Główna nawigacja"></nav>
-      <div class="header-actions">
-        <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="Przełącz motyw">
-          <span class="sun" aria-hidden="true"></span>
-          <span class="moon" aria-hidden="true"></span>
-          <span class="paper" aria-hidden="true"></span>
-        </button>
-        <a href="tel:+48793927467" class="btn primary">Zadzwoń 24/7</a>
-      </div>
-    </div>
-  </header>
 
   <main id="main">
     <!-- HERO: wideo ma W/H + poster (zero CLS) -->
@@ -106,8 +88,10 @@
       <div class="container"><small data-cms-key="footer_copy">© 2025 Kras-Trans • ul. Trzcinowa 14/11, 91-495 Łódź • <a href="tel:+48793927467">+48 793 927 467</a></small></div>
     </footer>
 
-    <script src="assets/js/kras-global.js" defer></script>
+    <script>window.KRAS_NAV_SRC = "/data/nav.json";</script>
+    <script src="assets/js/header-loader.js" defer></script>
     <script src="assets/js/menu-builder.js" defer></script>
+    <script src="assets/js/kras-global.js" defer></script>
     <script src="assets/js/cms-loader.js" defer></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- load site header from external partial for reuse across pages
- fetch navigation links from JSON config

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689fd9d7d81883338ad3882672d5d722