### PR TITLE
feat: build dynamic mega menu

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -52,6 +52,12 @@
   }
   .site-header :is(a,button){outline-offset:2px;}
   #mega-root{position:absolute;left:0;right:0;top:100%;background:var(--card);box-shadow:0 10px 40px rgba(0,0,0,.14);}
+  .nav__btn{background:none;border:0;padding:0;font:inherit;color:inherit;cursor:pointer;}
+  .nav__btn:hover,.nav__btn:focus{color:hsl(var(--accent-hue) 90% 45%);}
+  .panel{display:none;padding:24px 32px;}
+  .panel.is-open{display:block;}
+  .panel__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px;}
+  .panel__grid a{display:block;padding:4px 0;text-decoration:none;color:inherit;}
 
   .hero-wrap{display:grid;gap:clamp(24px,5vw,40px);}
   @media(min-width:800px){.hero-wrap{grid-template-columns:1fr 1fr;align-items:center;}}

--- a/assets/js/menu-builder.js
+++ b/assets/js/menu-builder.js
@@ -1,387 +1,206 @@
-/* KRAS • Menu Builder PRO (2025)
-   - źródła: #site-nav[data-src] → window.KRAS_NAV_SRC → window.KRAS_NAV → fallback z DOM
-   - hover desktop / click mobile, klawiatura (Up/Down/Left/Right/Home/End/Esc)
-   - focus trap w submenu, zamykanie poza, aktiivna ścieżka, języki (flagi)
-   - overflow shadows, lekkie API (window.KRASMenu)
-*/
+(function(){
+  'use strict';
 
-(function () {
-  "use strict";
-
-  const state = {
-    cfg: null,
-    nav: null,
-    list: null,
-    langs: null,
-    isTouch: matchMedia("(hover: none)").matches,
-    hoverDelay: 120,
-    closeDelay: 160,
-    timers: new WeakMap(), // dla hover open/close
-  };
-
-  const API = {
-    async init() {
-      state.nav = document.getElementById("site-nav");
-      if (!state.nav) return;
-
-      const cfg = await loadConfig();
-      state.cfg = cfg;
-      buildNav(cfg);
-      attachGlobalHandlers();
-      fire("kras:menu:ready", { cfg });
-    },
-    rebuild(newCfg) {
-      state.cfg = newCfg || state.cfg || { items: [], langs: [] };
-      buildNav(state.cfg);
-      fire("kras:menu:rebuild", { cfg: state.cfg });
-    },
-    set(newCfg) {
-      window.KRAS_NAV = newCfg;
-      API.rebuild(newCfg);
-    },
-    closeAll() {
-      closeAll();
-    },
-  };
-
-  // ------------- Helpers -------------
-  function fire(name, detail) {
-    document.dispatchEvent(new CustomEvent(name, { detail }));
-  }
-
-  function norm(url) {
-    try {
-      return new URL(url, location.origin).pathname.replace(/\/+$/, "") + "/";
-    } catch (_) {
-      return "/";
+  // --------- Data fetch ---------
+  async function loadCMS(){
+    if(window.CMS_DATA && window.CMS_DATA.nav){
+      return window.CMS_DATA;
     }
-  }
-
-  function currentPath() {
-    return norm(location.pathname);
-  }
-
-  function qsa(sel, ctx = document) {
-    return Array.from(ctx.querySelectorAll(sel));
-  }
-
-  function setTimer(el, fn, delay) {
-    clearTimer(el);
-    const id = setTimeout(fn, delay);
-    state.timers.set(el, id);
-  }
-
-  function clearTimer(el) {
-    const id = state.timers.get(el);
-    if (id) clearTimeout(id);
-    state.timers.delete(el);
-  }
-
-  // ------------- Data sources -------------
-  async function loadConfig() {
-    // 1) data-src na #site-nav
-    const srcAttr = state.nav?.dataset?.src;
-    if (srcAttr) {
-      const cfg = await fetchJSON(srcAttr);
-      if (cfg && (cfg.items?.length || cfg.langs?.length)) return cfg;
+    try{
+      const res = await fetch('/data/cms.json', {credentials:'omit'});
+      if(res.ok) return await res.json();
+    }catch(err){
+      console.warn('CMS fetch fail', err);
     }
-    // 2) window.KRAS_NAV_SRC (np. z Apps Script) – JSON endpoint
-    if (window.KRAS_NAV_SRC) {
-      const cfg = await fetchJSON(window.KRAS_NAV_SRC);
-      if (cfg && (cfg.items?.length || cfg.langs?.length)) return cfg;
-    }
-    // 3) window.KRAS_NAV (obiekt wstępnie wstrzyknięty w HTML)
-    if (window.KRAS_NAV && (window.KRAS_NAV.items?.length || window.KRAS_NAV.langs?.length)) {
-      return window.KRAS_NAV;
-    }
-    // 4) fallback: parsuj istniejący markup (prosty)
-    const fallback = parseExistingMarkup();
-    return fallback;
+    return {nav:[], strings:[], hreflang:{}};
   }
 
-  async function fetchJSON(url) {
-    try {
-      const res = await fetch(url, { credentials: "omit" });
-      if (!res.ok) return null;
-      return await res.json();
-    } catch (_) {
-      return null;
-    }
+  function slugify(str){
+    return str.toLowerCase().replace(/\s+/g,'-').replace(/[^a-z0-9-]/g,'');
   }
 
-  function parseExistingMarkup() {
-    const items = [];
-    const ul = state.nav.querySelector("ul,ol");
-    if (ul) {
-      ul.querySelectorAll(":scope > li").forEach((li) => {
-        const a = li.querySelector(":scope > a");
-        const btn = li.querySelector(":scope > button");
-        const entry = { label: "", href: "#", children: null };
-        if (a) {
-          entry.label = a.textContent.trim();
-          entry.href = a.getAttribute("href") || "#";
-        } else if (btn) {
-          entry.label = btn.textContent.trim();
-          entry.href = "#";
-        }
-        const sub = li.querySelector(":scope > ul, :scope > .sub");
-        if (sub) {
-          entry.children = [];
-          sub.querySelectorAll(":scope > li > a").forEach((aa) => {
-            entry.children.push({ label: aa.textContent.trim(), href: aa.getAttribute("href") || "#" });
-          });
-        }
-        if (entry.label) items.push(entry);
+  function samePath(href){
+    try{
+      const u=new URL(href, location.origin);
+      return u.pathname.replace(/\/+$/,'/')===location.pathname.replace(/\/+$/,'/');
+    }catch(_){ return false; }
+  }
+
+  function build(data){
+    const lang=(window.CMS_PAGE&&window.CMS_PAGE.lang)||document.documentElement.lang||'pl';
+    const slugKey=(window.CMS_PAGE&&window.CMS_PAGE.slugKey)||'';
+    const navItems=(data.nav||[]).filter(it=>it.lang===lang && it.enabled!=='FALSE' && it.href && !/^#/.test(it.href) && it.href!=='/#/');
+    navItems.sort((a,b)=>(+a.order||0)-(+b.order||0));
+    const groups={};
+    navItems.forEach(it=>{ if(it.parent){ const p=it.parent.trim(); (groups[p]=groups[p]||[]).push(it); } });
+    const top=navItems.filter(it=>!it.parent);
+
+    const siteNav=document.getElementById('site-nav');
+    const megaRoot=document.getElementById('mega-root');
+    const neon=document.getElementById('neon-menu');
+    if(!siteNav) return;
+
+    // ---- topbar ----
+    const ul=document.createElement('ul');
+    ul.className='nav__list';
+    top.forEach((item,i)=>{
+      const key=slugify(item.label||('grp'+i));
+      const li=document.createElement('li');
+      if(groups[item.label]) li.classList.add('has-panel');
+      let el;
+      if(groups[item.label]){
+        el=document.createElement('button');
+        el.type='button';
+        el.className='nav__btn';
+        el.dataset.panel=key;
+        el.setAttribute('aria-haspopup','true');
+        el.setAttribute('aria-expanded','false');
+        el.addEventListener('click', ()=>togglePanel(key));
+        el.addEventListener('mouseenter',()=>togglePanel(key,true));
+      }else{
+        el=document.createElement('a');
+        el.href=item.href;
+        if(samePath(item.href)) el.setAttribute('aria-current','page');
+      }
+      el.textContent=item.label;
+      li.appendChild(el);
+      ul.appendChild(li);
+    });
+    siteNav.innerHTML='';
+    siteNav.appendChild(ul);
+    siteNav.hidden=false;
+
+    // ---- mega panels ----
+    megaRoot.innerHTML='';
+    Object.entries(groups).forEach(([name, items])=>{
+      const key=slugify(name);
+      const panel=document.createElement('div');
+      panel.className='panel';
+      panel.dataset.panel=key;
+      panel.hidden=true;
+      const grid=document.createElement('div');
+      grid.className='panel__grid';
+      items.sort((a,b)=>(+a.order||0)-(+b.order||0)).forEach(ch=>{
+        const a=document.createElement('a');
+        a.href=ch.href;
+        a.textContent=ch.label;
+        grid.appendChild(a);
       });
-    }
-    const langs = [];
-    qsa(".nav-langs .lang").forEach((a) => {
-      langs.push({ code: a.dataset.lang || a.textContent.trim(), label: a.textContent.trim(), href: a.href });
+      panel.appendChild(grid);
+      megaRoot.appendChild(panel);
     });
-    return { items, langs };
-  }
 
-  // ------------- Build -------------
-  function buildNav(cfg) {
-    const nav = state.nav;
-    nav.innerHTML = "";
-
-    // wrapper
-    const shell = document.createElement("div");
-    shell.className = "nav-shell";
-    nav.appendChild(shell);
-
-    // list
-    const list = document.createElement("ul");
-    list.className = "nav__list";
-    list.setAttribute("role", "menubar");
-    shell.appendChild(list);
-    state.list = list;
-
-    // items
-    const path = currentPath();
-    for (const it of cfg.items || []) {
-      const li = document.createElement("li");
-      li.setAttribute("role", "none");
-
-      if (it.children && it.children.length) {
-        li.className = "has-sub";
-        li.setAttribute("aria-expanded", "false");
-
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "nav-toggle";
-        btn.innerHTML = `<span>${it.label}</span>`;
-        btn.setAttribute("role", "menuitem");
-        btn.setAttribute("aria-haspopup", "true");
-        btn.setAttribute("aria-expanded", "false");
-        btn.addEventListener("click", () => toggleDropdown(li, true));
-
-        if (!state.isTouch) {
-          li.addEventListener("mouseenter", () => setTimer(li, () => toggleDropdown(li, true), state.hoverDelay));
-          li.addEventListener("mouseleave", () => setTimer(li, () => toggleDropdown(li, false), state.closeDelay));
-        }
-
-        const sub = document.createElement("ul");
-        sub.className = "sub";
-        sub.hidden = true;
-        sub.setAttribute("role", "menu");
-
-        for (const ch of it.children) {
-          const li2 = document.createElement("li");
-          li2.setAttribute("role", "none");
-          const a = document.createElement("a");
-          a.href = ch.href;
-          a.textContent = ch.label;
-          a.setAttribute("role", "menuitem");
-          if (norm(a.href) === path) a.classList.add("active");
-          li2.appendChild(a);
-          sub.appendChild(li2);
-        }
-
-        li.append(btn, sub);
-      } else {
-        const a = document.createElement("a");
-        a.href = it.href || "#";
-        a.textContent = it.label;
-        a.setAttribute("role", "menuitem");
-        try {
-          if (norm(a.href) === path) a.classList.add("active");
-        } catch (_) {}
+    // ---- neon menu ----
+    if(neon){
+      const dock=document.getElementById('dock-menu');
+      const closeBtn=neon.querySelector('.neon__close');
+      const navEl=neon.querySelector('.neon__nav');
+      const langsEl=neon.querySelector('.neon__langs');
+      navEl.innerHTML='';
+      const list=document.createElement('ul');
+      top.forEach((item,i)=>{
+        const li=document.createElement('li');
+        const a=document.createElement('a');
+        a.href=item.href;
+        a.textContent=item.label;
         li.appendChild(a);
+        if(groups[item.label]){
+          const sub=document.createElement('ul');
+          groups[item.label].forEach(ch=>{
+            const si=document.createElement('li');
+            const sa=document.createElement('a');
+            sa.href=ch.href; sa.textContent=ch.label; si.appendChild(sa); sub.appendChild(si);
+          });
+          li.appendChild(sub);
+        }
+        list.appendChild(li);
+      });
+      navEl.appendChild(list);
+
+      // languages
+      langsEl.innerHTML='';
+      const langs=(data.hreflang||{})[slugKey]||{};
+      Object.entries(langs).forEach(([L,href])=>{
+        const a=document.createElement('a');
+        a.href=href;
+        a.lang=L==='ua'?'uk':L;
+        a.textContent=a.lang;
+        langsEl.appendChild(a);
+      });
+
+      let lastFocus=null;
+      function trapTab(e){
+        if(e.key!=='Tab') return;
+        const f=neon.querySelectorAll('a,button');
+        if(!f.length) return;
+        const first=f[0], last=f[f.length-1];
+        if(e.shiftKey && document.activeElement===first){e.preventDefault();last.focus();}
+        else if(!e.shiftKey && document.activeElement===last){e.preventDefault();first.focus();}
       }
-      list.appendChild(li);
+      function openNeon(){
+        lastFocus=document.activeElement;
+        neon.classList.add('is-open');
+        neon.hidden=false;
+        document.addEventListener('keydown',trapTab);
+        neon.addEventListener('keydown',neonEsc);
+        navEl.querySelector('a,button')?.focus();
+      }
+      function closeNeon(){
+        neon.classList.remove('is-open');
+        neon.hidden=true;
+        document.removeEventListener('keydown',trapTab);
+        neon.removeEventListener('keydown',neonEsc);
+        lastFocus?.focus();
+      }
+      function neonEsc(e){ if(e.key==='Escape') closeNeon(); }
+      dock?.addEventListener('click',openNeon);
+      closeBtn?.addEventListener('click',closeNeon);
+      neon.addEventListener('click',e=>{ if(e.target===neon) closeNeon(); });
     }
 
-    // languages
-    const langWrap = document.createElement("div");
-    langWrap.className = "nav-langs";
-    shell.appendChild(langWrap);
-    state.langs = langWrap;
-
-    (cfg.langs || []).forEach((lng) => {
-      const a = document.createElement("a");
-      a.className = "lang";
-      a.href = lng.href || "#";
-      const code = (lng.code || "").toLowerCase();
-      a.setAttribute("data-lang", code);
-      a.innerHTML = `<span class="flag" aria-hidden="true"></span><span class="sr-only">${lng.label || code}</span>`;
-      // current language mark
-      try {
-        if (norm(a.href) === path) a.classList.add("active");
-      } catch (_) {}
-      langWrap.appendChild(a);
-    });
-
-    // overflow shadows on nav__list
-    attachOverflowShadows(list);
-    nav.hidden = false;
-  }
-
-  // ------------- Dropdown control -------------
-  function closeAll(except) {
-    qsa(".has-sub[aria-expanded='true']", state.nav).forEach((li) => {
-      if (except && li === except) return;
-      li.setAttribute("aria-expanded", "false");
-      const sub = li.querySelector(".sub");
-      if (sub) sub.hidden = true;
-      const btn = li.querySelector(".nav-toggle");
-      if (btn) btn.setAttribute("aria-expanded", "false");
-    });
-    document.removeEventListener("click", onOutsideClick, true);
-  }
-
-  function toggleDropdown(li, wantToggle) {
-    clearTimer(li);
-    const open = li.getAttribute("aria-expanded") === "true";
-    const willOpen = typeof wantToggle === "boolean" ? wantToggle : !open;
-
-    if (willOpen) {
-      closeAll(li);
-      li.setAttribute("aria-expanded", "true");
-      const sub = li.querySelector(".sub");
-      if (sub) sub.hidden = false;
-      const btn = li.querySelector(".nav-toggle");
-      if (btn) btn.setAttribute("aria-expanded", "true");
-      document.addEventListener("click", onOutsideClick, true);
-      // focus first link when opened by keyboard
-      if (document.activeElement === btn) {
-        const first = li.querySelector(".sub a");
-        first && first.focus();
+    // ---- panel interactions ----
+    const header=document.querySelector('.site-header');
+    let open=null;
+    function togglePanel(key,fromHover=false){
+      const panel=megaRoot.querySelector(`.panel[data-panel="${key}"]`);
+      const btn=siteNav.querySelector(`.nav__btn[data-panel="${key}"]`);
+      if(open && open.panel!==panel){ closePanel(); }
+      if(panel && (open?.panel!==panel || fromHover)){
+        const willOpen=panel.hidden;
+        closePanel();
+        if(willOpen){
+          panel.hidden=false; panel.classList.add('is-open');
+          btn.setAttribute('aria-expanded','true');
+          open={panel,btn};
+          if(document.activeElement===btn) panel.querySelector('a')?.focus();
+        }
+      }else{
+        closePanel();
       }
-    } else {
-      li.setAttribute("aria-expanded", "false");
-      const sub = li.querySelector(".sub");
-      if (sub) sub.hidden = true;
-      const btn = li.querySelector(".nav-toggle");
-      if (btn) btn.setAttribute("aria-expanded", "false");
     }
-  }
-
-  function onOutsideClick(e) {
-    if (!state.nav.contains(e.target)) closeAll();
-  }
-
-  // ------------- Keyboard -------------
-  function attachGlobalHandlers() {
-    // keyboard on menubar + submenus (delegated)
-    state.nav.addEventListener("keydown", (e) => {
-      const tgt = e.target;
-      const topItems = qsa(".nav__list > li > a, .nav__list > li > .nav-toggle", state.nav);
-      const idx = topItems.indexOf(tgt);
-
-      // Menubar level
-      if (idx > -1) {
-        if (e.key === "ArrowRight") {
-          e.preventDefault();
-          (topItems[idx + 1] || topItems[0])?.focus();
-        }
-        if (e.key === "ArrowLeft") {
-          e.preventDefault();
-          (topItems[idx - 1] || topItems.at(-1))?.focus();
-        }
-        if (e.key === "Home") {
-          e.preventDefault();
-          topItems[0]?.focus();
-        }
-        if (e.key === "End") {
-          e.preventDefault();
-          topItems.at(-1)?.focus();
-        }
-        if (e.key === "ArrowDown") {
-          // open submenu if present
-          const host = tgt.closest(".has-sub");
-          if (host) {
-            e.preventDefault();
-            toggleDropdown(host, true);
-            host.querySelector(".sub a")?.focus();
-          }
-        }
-        if (e.key === "Escape") {
-          e.preventDefault();
-          closeAll();
-          topItems[0]?.focus();
-        }
-        return;
-      }
-
-      // Inside submenu
-      const sub = tgt.closest(".sub");
-      if (sub) {
-        const items = qsa("a", sub);
-        const i = items.indexOf(tgt);
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          (items[i + 1] || items[0])?.focus();
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          (items[i - 1] || items.at(-1))?.focus();
-        }
-        if (e.key === "Home") {
-          e.preventDefault();
-          items[0]?.focus();
-        }
-        if (e.key === "End") {
-          e.preventDefault();
-          items.at(-1)?.focus();
-        }
-        if (e.key === "Escape") {
-          e.preventDefault();
-          const host = sub.closest(".has-sub");
-          toggleDropdown(host, false);
-          host.querySelector(".nav-toggle")?.focus();
-        }
-      }
-    });
-
-    // Rebuild on resize if needed (głównie cienie overflow)
-    addEventListener("resize", () => {
-      attachOverflowShadows(state.list);
-      closeAll();
-    });
-  }
-
-  // ------------- Overflow shadows -------------
-  function attachOverflowShadows(scroller) {
-    if (!scroller) return;
-    function update() {
-      const left = scroller.scrollLeft > 0;
-      const right = Math.ceil(scroller.scrollLeft + scroller.clientWidth) < scroller.scrollWidth;
-      scroller.classList.toggle("shadow-left", left);
-      scroller.classList.toggle("shadow-right", right);
+    function closePanel(){
+      if(!open) return;
+      open.panel.hidden=true;
+      open.panel.classList.remove('is-open');
+      open.btn.setAttribute('aria-expanded','false');
+      open=null;
     }
-    scroller.addEventListener("scroll", update, { passive: true });
-    // po krótkiej chwili (fonts) zaktualizuj
-    setTimeout(update, 120);
+    header?.addEventListener('mouseleave', closePanel);
+    document.addEventListener('click',e=>{ if(open && !header.contains(e.target)) closePanel(); });
+    document.addEventListener('keydown',e=>{ if(e.key==='Escape') closePanel(); });
+
+    // keyboard nav for top level
+    siteNav.addEventListener('keydown',e=>{
+      const items=[...siteNav.querySelectorAll('.nav__list > li > .nav__btn, .nav__list > li > a')];
+      const i=items.indexOf(document.activeElement);
+      if(i>-1){
+        if(e.key==='ArrowRight'){ e.preventDefault(); (items[i+1]||items[0]).focus(); }
+        if(e.key==='ArrowLeft'){ e.preventDefault(); (items[i-1]||items.at(-1)).focus(); }
+        if(e.key==='ArrowDown' && document.activeElement.classList.contains('nav__btn')){ e.preventDefault(); togglePanel(document.activeElement.dataset.panel); }
+        if(e.key==='Escape'){ e.preventDefault(); closePanel(); items[0].focus(); }
+      }
+    });
   }
 
-  // ------------- Kick-off -------------
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", API.init, { once: true });
-  } else {
-    API.init();
-  }
-
-  window.KRASMenu = API;
+  loadCMS().then(build);
 })();


### PR DESCRIPTION
## Summary
- build menu-builder to generate navigation, mega-panels and neon mobile menu from CMS data
- add basic styles for menu buttons and panels

## Testing
- `python tools/build.py`
- `cat dist/robots.txt`
- `head -n 20 dist/sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_689fecc7093883339a8ef56973ecdcb2