### PR TITLE
Defer heavy JS init to improve LCP

### DIFF
--- a/assets/js/kras-global.js
+++ b/assets/js/kras-global.js
@@ -10,6 +10,7 @@
   const $$ = (sel, ctx=document) => Array.from(ctx.querySelectorAll(sel));
   const on = (el, ev, fn, opts) => el && el.addEventListener(ev, fn, opts);
   const raf = (fn) => (window.requestAnimationFrame||setTimeout)(fn,16);
+  const rIC = window.requestIdleCallback || (cb => setTimeout(cb,1));
   const clamp = (v,min,max) => Math.max(min, Math.min(max, v));
   const ls = {
     get: (k, d=null) => { try{ return JSON.parse(localStorage.getItem(k)); }catch{ return d; } },
@@ -362,19 +363,19 @@
     Theme.apply();
     Theme.ensureButton();
     setTimeout(()=>Theme.tipBubble(), 1800);
-
-    initCanvas();
-    initHScroll();
-    equalizeHeights();
-    initSmoothAnchors();
-    initLazyMedia();
-    initAjaxForms();
-    initDock();
-    initQuoteHelper();
-    initMenuToggle();
-
-    // equalize again on resizes
-    eqObserver.observe(document.body);
+    rIC(() => {
+      initCanvas();
+      initHScroll();
+      equalizeHeights();
+      initSmoothAnchors();
+      initLazyMedia();
+      initAjaxForms();
+      initDock();
+      initQuoteHelper();
+      initMenuToggle();
+      // equalize again on resizes
+      eqObserver.observe(document.body);
+    });
   });
 
 })();


### PR DESCRIPTION
## Summary
- defer expensive UI setup until the browser is idle
- polyfill `requestIdleCallback` for older browsers

## Testing
- `node --check assets/js/kras-global.js && echo "Syntax OK"`
- `python -m py_compile $(git ls-files '*.py') && echo "Py compile OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a03c22b73883339a72a75fadc58ea0