### PR TITLE
Optimize render path for faster page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,11 @@
   <title>Kras-Trans — Ekspresowy transport 3,5 t i TIR • Polska & UE</title>
   <meta name="description" content="Transport ekspresowy i dedykowany: busy do 3,5 t i TIR. Łódź, Polska, cała UE. 24/7, monitoring GPS, OC przewoźnika." />
   <link rel="preload" as="video" href="assets/media/hero.mp4" />
-  <link rel="stylesheet" href="assets/css/kras-global.css" />
+  <link rel="preload" href="assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="assets/css/kras-global.css" as="style" />
+  <link rel="stylesheet" href="assets/css/kras-global.css" media="print" onload="this.media='all'" />
+  <noscript><link rel="stylesheet" href="assets/css/kras-global.css" /></noscript>
 </head>
 <body>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,16 @@
   <meta property="og:description" content="{{ head.og_description }}">
   <meta property="og:image" content="{{ head.og_image }}">
   <meta property="og:type" content="website">
-  <link rel="stylesheet" href="/assets/css/kras-global.css">
-  <link rel="stylesheet" href="/assets/css/kras-ui.css">
+  <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/css/kras-global.css" as="style">
+  <link rel="preload" href="/assets/css/kras-ui.css" as="style">
+  <link rel="stylesheet" href="/assets/css/kras-global.css" media="print" onload="this.media='all'">
+  <link rel="stylesheet" href="/assets/css/kras-ui.css" media="print" onload="this.media='all'">
+  <noscript>
+    <link rel="stylesheet" href="/assets/css/kras-global.css">
+    <link rel="stylesheet" href="/assets/css/kras-ui.css">
+  </noscript>
   {% for ld in head.jsonld %}
   <script type="application/ld+json">{{ ld|tojson }}</script>
   {% endfor %}
@@ -61,6 +69,6 @@
   <script>window.KRAS_NAV = {{ nav_cfg|tojson }};</script>
   <script src="/assets/js/kras-global.js" defer></script>
   <script src="/assets/js/menu-builder.js" defer></script>
-  <script src="/assets/js/kras-ui.js" defer></script>
+  <script>(window.requestIdleCallback||window.setTimeout)(function(){var s=document.createElement('script');s.src='/assets/js/kras-ui.js';s.defer=true;document.body.appendChild(s);});</script>
 </body>
 </html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -19,9 +19,16 @@
   <meta name="twitter:description" content="{{ page.meta_desc or page.lead }}">
   <meta name="twitter:image" content="{{ page.og_image or '/assets/media/og-default.jpg' }}">
   <link rel="canonical" href="{{ _canon }}">
-  <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin media="(min-width:768px)">
-  <link rel="stylesheet" href="/assets/css/kras-global.css">
-  <link rel="stylesheet" href="/assets/css/kras-ui.css">
+  <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/css/kras-global.css" as="style">
+  <link rel="preload" href="/assets/css/kras-ui.css" as="style">
+  <link rel="stylesheet" href="/assets/css/kras-global.css" media="print" onload="this.media='all'">
+  <link rel="stylesheet" href="/assets/css/kras-ui.css" media="print" onload="this.media='all'">
+  <noscript>
+    <link rel="stylesheet" href="/assets/css/kras-global.css">
+    <link rel="stylesheet" href="/assets/css/kras-ui.css">
+  </noscript>
   <style>.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0}</style>
   <script>
     // zakładamy: window.CMS_PAGE = { slugKey:'…', lang:'pl' }
@@ -192,6 +199,6 @@
   <script>window.KRAS_NAV = {{ nav_cfg|tojson }};</script>
   <script src="/assets/js/kras-global.js" defer></script>
   <script src="/assets/js/menu-builder.js" defer></script>
-  <script src="/assets/js/kras-ui.js" defer></script>
+  <script>(window.requestIdleCallback||window.setTimeout)(function(){var s=document.createElement('script');s.src='/assets/js/kras-ui.js';s.defer=true;document.body.appendChild(s);});</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load global styles without blocking rendering via preload, `media="print"` switch, and noscript fallbacks
- Preload Inter fonts to avoid layout delays
- Lazy-load UI script after idle to reduce main-thread work

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a03f28b88c8333abc7de16cc595360