### PR TITLE
feat: add modern responsive homepage template

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -1,135 +1,361 @@
-@layer base, components, utilities;
+/* Root theme variables and base styles */
+:root {
+  color-scheme: light dark;
+  /* Kolor akcentu domyślny (hue w stopniach) */
+  --accent-hue: 22;
+  /* Kolory bazowe dla motywu jasnego */
+  --bg: #ffffff;
+  --ink: #1f1f1f;
+  --muted: #6b7280;
+  --card: #ffffff;
+}
+:root[data-theme="dark"] {
+  /* Kolory dla trybu ciemnego */
+  --bg: #0b0f17;
+  --ink: #e9edf5;
+  --muted: #8a94a7;
+  --card: #12151d;
+}
+:root[data-theme="ebook"] {
+  /* Kolory dla trybu e-book (papier) */
+  --bg: #F7F3E8;
+  --ink: #1C1A16;
+  --muted: #6B665E;
+  --card: #FBF8EF;
+}
+/* Wczytanie fontu Inter (zmienna) z subsetem (latin+ext) */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  size-adjust: 100%;
+  src: url("/assets/fonts/InterVariable.woff2") format("woff2-variations");
+  unicode-range: U+000-5FF; /* basic Latin + PL */
+}
+/* Preferencja reduce-motion: wyłączenie animacji i przejść, dopóki .no-motion jest na <html> */
+html.no-motion *, 
+html.no-motion *::before, 
+html.no-motion *::after {
+  animation: none !important;
+  transition: none !important;
+}
+/* Utillity class for screen readers (duplicate of .visually-hidden from HTML <style>) */
+.sr-only { position: absolute !important; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); clip-path: inset(50%); white-space:nowrap; border:0; }
 
-@layer base {
-  :root {
-    color-scheme: light dark;
-    --accent-hue:22;
-    --bg:#ffffff;
-    --ink:#1f1f1f;
-    --muted:#6b7280;
-    --card:#ffffff;
+/* --- Component styles --- */
+
+/* Site header (sticky top bar) */
+.site-header {
+  position: sticky;
+  top: 0; z-index: 40;
+  backdrop-filter: saturate(1.2) blur(8px);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 15%, transparent);
+  overflow: clip;
+}
+.site-header a, .site-header button { outline-offset: 2px; }  /* focus outline spacing */
+#mega-root { 
+  position: absolute; left: 0; right: 0; top: 100%; 
+  background: var(--card); 
+  box-shadow: 0 10px 40px rgba(0,0,0,0.14);
+}
+/* (Mega-menu panels and grid would be here, if needed) */
+
+/* Theme toggle button icons */
+.theme-toggle { position: relative; }
+.theme-toggle .sun, .theme-toggle .moon, .theme-toggle .paper {
+  display: inline-block;
+  width: 16px; height: 16px;
+  background: currentColor;
+  mask-size: contain; mask-position: center; mask-repeat: no-repeat;
+}
+/* (Here you could define mask-image: url() for sun, moon, paper icons if using SVG icons) */
+.theme-hint {
+  position: absolute;
+  top: 100%; right: 0;
+  background: var(--card);
+  color: var(--ink);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.theme-hint.show { opacity: 1; }
+
+/* Hero section layout */
+.hero-wrap { 
+  display: grid; 
+  gap: clamp(24px, 5vw, 40px); 
+}
+@media (min-width: 800px) {
+  .hero-wrap { 
+    grid-template-columns: 1fr 1fr; 
+    align-items: center;
   }
-  :root[data-theme="dark"]{
-    --bg:#0b0f17;
-    --ink:#e9edf5;
-    --muted:#8a94a7;
-    --card:#12151d;
-  }
-  :root[data-theme="ebook"]{
-    --bg:#F7F3E8;
-    --ink:#1C1A16;
-    --muted:#6B665E;
-    --card:#FBF8EF;
-  }
-  @font-face{
-    font-family:"Inter";
-    font-style:normal;
-    font-weight:100 900;
-    font-display:swap;
-    size-adjust:100%;
-    src:url("/assets/fonts/InterVariable.woff2") format("woff2-variations");
-    unicode-range:U+000-5FF;
-  }
-  html.no-motion *,
-  html.no-motion *::before,
-  html.no-motion *::after{
-    animation:none!important;
-    transition:none!important;
-  }
-  @media (prefers-reduced-motion:reduce){
-    html.no-motion{ }
-  }
-  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+}
+.hero-media {
+  width: 100%; height: auto;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.hero.is-ready .hero-media { opacity: 1; }  /* Po załadowaniu hero, odsłania obraz/wideo */
+
+/* Cards grid & styles */
+.cards { display: grid; gap: clamp(16px, 3vw, 32px); }
+.cards--wrap { grid-auto-flow: column; }  /* horizontal wrapping for card container */
+.cards--scroll { 
+  display: flex; overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.cards--scroll .card { 
+  flex: 0 0 clamp(260px, 80vw, 340px);
+  scroll-snap-align: start;
+}
+.card {
+  background: var(--card);
+  border-radius: var(--r, 16px);
+  box-shadow: var(--shadow-1, 0 4px 18px rgba(0,0,0,0.08));
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+.card > .pad { padding: clamp(16px, 3vw, 24px); } /* inner padding wrapper if needed */
+.card:hover, .card:focus-within { transform: translateY(-2px); }  /* subtle lift on hover/focus */
+.card:hover img, .card:focus-within img { transform: scale(1.05); }  /* zoom image on hover */
+.card.glass { 
+  background: color-mix(in srgb, var(--card) 60%, transparent);
+  backdrop-filter: blur(8px);
+}
+.card.edge { 
+  border: 1px solid color-mix(in srgb, var(--ink) 20%, transparent);
+}
+.card.soft3d { 
+  box-shadow: 0 6px 12px rgba(0,0,0,0.12), 0 1px 0 rgba(255,255,255,0.05) inset;
+}
+.card.illume { 
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ink) 10%, transparent),
+              0 0 8px hsl(var(--accent-hue) 80% 60% / 35%);
 }
 
-@layer components {
-  .site-header{
-    position:sticky;top:0;z-index:40;
-    backdrop-filter:saturate(1.2) blur(8px);
-    background:color-mix(in srgb,var(--bg) 70%, transparent);
-    border-bottom:1px solid color-mix(in srgb,var(--ink) 15%, transparent);
-    overflow:clip;
-  }
-  .site-header :is(a,button){outline-offset:2px;}
-  #mega-root{position:absolute;left:0;right:0;top:100%;background:var(--card);box-shadow:0 10px 40px rgba(0,0,0,.14);}
-  .nav__btn{background:none;border:0;padding:0;font:inherit;color:inherit;cursor:pointer;}
-  .nav__btn:hover,.nav__btn:focus{color:hsl(var(--accent-hue) 90% 45%);}
-  .panel{display:none;padding:24px 32px;}
-  .panel.is-open{display:block;}
-  .panel__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px;}
-  .panel__grid a{display:block;padding:4px 0;text-decoration:none;color:inherit;}
-
-  .hero-wrap{display:grid;gap:clamp(24px,5vw,40px);}
-  @media(min-width:800px){.hero-wrap{grid-template-columns:1fr 1fr;align-items:center;}}
-  .hero-media{width:100%;height:auto;opacity:0;transition:opacity .6s ease;}
-  .hero.is-ready .hero-media{opacity:1;}
-
-  .cards{display:grid;gap:clamp(16px,3vw,32px);}
-  .cards--wrap{grid-auto-flow:column;}
-  .cards--scroll{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;}
-  .cards--scroll .card{flex:0 0 clamp(260px,80vw,340px);scroll-snap-align:start;}
-  .card{background:var(--card);border-radius:var(--r,16px);box-shadow:var(--shadow-1,0 4px 18px rgba(0,0,0,.08));transition:transform .3s;}
-  .card>.pad{padding:clamp(16px,3vw,24px);}
-  .card.glass{background:color-mix(in srgb,var(--card) 60%,transparent);backdrop-filter:blur(8px);}
-  .card.edge{border:1px solid color-mix(in srgb,var(--ink) 20%,transparent);}
-  .card.soft3d{box-shadow:0 6px 12px rgba(0,0,0,.12),0 1px 0 rgba(255,255,255,.05) inset;}
-  .card.illume{box-shadow:0 0 0 1px color-mix(in srgb,var(--ink) 10%,transparent),0 0 8px hsl(var(--accent-hue) 80% 60% / .35);}
-  .tilt-cards{perspective:1000px;}
-  .tilt-cards .card{transform-style:preserve-3d;}
-  .tilt-cards .card:is(:hover,:focus-within){transform:translateY(-4px) rotateX(1.5deg) rotateY(-1.5deg);}
-
-  /* Split Hero (napis -> rail w tym samym miejscu) */
-  .split-hero{ position:relative; height:140vh; }
-  .split-hero__sticky{ position:sticky; top:calc(54px + 1svh); display:grid; place-items:center; padding-block:clamp(18px,4vh,32px); min-height:clamp(340px,58vh,680px); z-index:1; }
-  .split-hero__stack{ --stack-h:clamp(140px,14vw,220px); position:relative; width:min(var(--offer-maxw,860px),92vw); height:var(--stack-h); margin-inline:auto; container-type:inline-size; }
-  .split-hero--narrow .split-hero__stack{ --offer-maxw:860px }
-  .split-hero--wide .split-hero__stack{ --offer-maxw:1100px }
-  .split-hero__stack > *{ position:absolute; inset:0 }
-  .split-hero__title{ opacity:calc(1 - var(--p,0)); transition:opacity .2s linear }
-  .title-half{ display:grid; place-items:center; line-height:1; text-transform:uppercase; font-weight:900; font-size:clamp(36px,16cqw,96px); letter-spacing:.04em; color:var(--ink); text-shadow:0 1px 0 color-mix(in oklab, var(--ink) 10%, transparent); will-change:transform,opacity }
-  .title-left { clip-path: inset(0 50% 0 0); transform: translateX(calc(-50cqw * var(--p, 0))); }
-  .title-right{ clip-path: inset(0 0 0 50%); transform: translateX(calc( 50cqw * var(--p, 0))); }
-  .split-hero__rail{ display:grid; grid-auto-flow: column; grid-auto-columns: clamp(220px, 42cqw, 360px); gap:16px; overflow-x:auto; padding:6px; scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; align-items:stretch; height:100%; opacity: var(--p, 0); transform: translateY(calc(14px * (1 - var(--p, 0)))); transition: opacity .2s linear, transform .2s ease; pointer-events:none; }
-  .split-hero__rail > *{ scroll-snap-align:start }
-  .offer-card{ position:relative; height:100%; border-radius:18px; overflow:hidden; isolation:isolate; background:var(--card); border:1px solid color-mix(in srgb,var(--ink) 20%, transparent); box-shadow:var(--shadow-1,0 4px 18px rgba(0,0,0,.08)); }
-  .offer-card img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; transform:scale(1.02); transition:transform .35s ease }
-  .offer-card::after{ content:""; position:absolute; inset:0; background:linear-gradient(180deg,transparent,rgba(0,0,0,.35) 68%,rgba(0,0,0,.55)); mix-blend-mode:multiply; pointer-events:none }
-  .offer-card__title,.offer-card__desc{ position:absolute; left:16px; right:16px; color:#fff; z-index:1; text-shadow:0 1px 2px rgba(0,0,0,.4) }
-  .offer-card__title{ bottom:42px; font-weight:800; font-size:clamp(15px,7cqw,20px) }
-  .offer-card__desc { bottom:14px; font-size:clamp(12px,5cqw,14px); opacity:.95 }
-  @media (hover:hover){ .offer-card:hover img{ transform:scale(1.06) } }
-  @supports not (container-type: inline-size){
-    .title-left { transform: translateX(calc(-28vw * var(--p, 0))) }
-    .title-right{ transform: translateX(calc( 28vw * var(--p, 0))) }
-    .split-hero__rail{ grid-auto-columns: clamp(220px, 45vw, 360px) }
-  }
-  @media (prefers-reduced-motion: reduce){
-    .title-left,.title-right{ transform:none !important }
-    .split-hero__title{ opacity:0 !important }
-    .split-hero__rail{ opacity:1 !important; transform:none !important; pointer-events:auto !important }
-  }
-
-  .bottom-dock{position:fixed;bottom:0;left:0;right:0;z-index:50;display:flex;justify-content:space-around;padding:4px env(safe-area-inset-right) calc(4px + env(safe-area-inset-bottom)) env(safe-area-inset-left);background:var(--card);box-shadow:0 -2px 10px rgba(0,0,0,.08);}
-  .dock-btn{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;background:none;border:0;padding:6px 0;font-size:10px;line-height:1;color:var(--ink);}
-  .dock-btn span{width:24px;height:24px;margin-bottom:2px;background:currentColor;mask-repeat:no-repeat;mask-position:center;mask-size:contain;}
-  .dock-home span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 12l9-9 9 9v9h-6v-6h-6v6H3z"/></svg>');}
-  .dock-quote span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M6.6 10.8a15 15 0 0 0 6.6 6.6l2.2-2.2a1 1 0 0 1 1.1-.2 11.4 11.4 0 0 0 3.5 1.6 1 1 0 0 1 1 1v3.5a1 1 0 0 1-1 1A17.5 17.5 0 0 1 2 6a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .6 3.5 1 1 0 0 1-.2 1.1z"/></svg>');}
-  .dock-menu span{mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 6h18M3 12h18M3 18h18" stroke="black" stroke-width="2" stroke-linecap="round"/></svg>');}
-  .dock-btn.dock-quote{flex:1.4;transform:translateY(-8px);}
-  .dock-btn em{font-style:normal;}
-
-  .neon{position:fixed;inset:0;display:none;background:rgba(0,0,0,.8);backdrop-filter:blur(12px);align-items:center;justify-content:center;}
-  .neon.is-open{display:flex;}
-  .neon__inner{background:var(--card);color:var(--ink);padding:32px;border-radius:var(--r,16px);box-shadow:0 0 0 4px hsl(var(--accent-hue) 90% 60% / .8);max-height:90vh;overflow:auto;min-width:min(90vw,400px);position:relative;}
-  .neon__nav a{display:block;padding:8px 0;color:inherit;text-decoration:none;}
-  .neon__close{position:absolute;top:16px;right:16px;background:none;border:0;font-size:32px;line-height:1;color:inherit;}
-
-  :root[data-theme="ebook"] body{background:var(--bg);color:var(--ink);}
-  :root[data-theme="ebook"] .content{max-width:68ch;margin-inline:auto;line-height:1.75;}
-  :root[data-theme="ebook"] p,
-  :root[data-theme="ebook"] li{text-align:justify;}
+/* 3D tilt effect for cards container */
+.tilt-cards { perspective: 1000px; }
+.tilt-cards .card { transform-style: preserve-3d; }
+.tilt-cards .card:hover, 
+.tilt-cards .card:focus-within {
+  transform: translateY(-4px) rotateX(1.5deg) rotateY(-1.5deg);
 }
 
-@layer utilities {
-  .is-hidden{display:none!important;}
+/* Split-hero (offer section) layout */
+.split-hero { position: relative; height: 140vh; }
+.split-hero__sticky { 
+  position: sticky; top: calc(54px + 1svh); z-index: 1;
+  display: grid; place-items: center;
+  padding-block: clamp(18px, 4vh, 32px);
+  min-height: clamp(340px, 58vh, 680px);
+}
+.split-hero__stack { 
+  --stack-h: clamp(140px, 14vw, 220px);
+  position: relative;
+  width: min(var(--offer-maxw, 860px), 92vw);
+  height: var(--stack-h);
+  margin-inline: auto;
+  container-type: inline-size;
+}
+.split-hero--narrow .split-hero__stack { --offer-maxw: 860px; }
+.split-hero--wide   .split-hero__stack { --offer-maxw: 1100px; }
+.split-hero__stack > * { position: absolute; inset: 0; }
+.split-hero__title { 
+  opacity: calc(1 - var(--p, 0));
+  transition: opacity 0.2s linear;
+}
+.title-half { 
+  display: grid; place-items: center;
+  line-height: 1; text-transform: uppercase;
+  font-weight: 900;
+  font-size: clamp(36px, 16cqw, 96px);
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  text-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 10%, transparent);
+  will-change: transform, opacity;
+}
+.title-left  { 
+  clip-path: inset(0 50% 0 0);
+  transform: translateX(calc(-50cqw * var(--p, 0)));
+}
+.title-right {
+  clip-path: inset(0 0 0 50%);
+  transform: translateX(calc( 50cqw * var(--p, 0)));
+}
+.split-hero__rail {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: clamp(220px, 42cqw, 360px);
+  gap: 16px;
+  overflow-x: auto;
+  padding: 6px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  align-items: stretch;
+  height: 100%;
+  opacity: var(--p, 0);
+  transform: translateY(calc(14px * (1 - var(--p, 0))));
+  transition: opacity 0.2s linear, transform 0.2s ease;
+  pointer-events: none;
+}
+.split-hero__rail > * { scroll-snap-align: start; }
+.offer-card {
+  position: relative;
+  height: 100%;
+  border-radius: 18px;
+  overflow: hidden;
+  isolation: isolate;
+  background: var(--card);
+  border: 1px solid color-mix(in srgb, var(--ink) 20%, transparent);
+  box-shadow: var(--shadow-1, 0 4px 18px rgba(0,0,0,0.08));
+}
+.offer-card img {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scale(1.02);
+  transition: transform 0.35s ease;
+}
+.offer-card__title {
+  position: absolute; left: 0; right: 0; bottom: 24px;
+  padding: 0 16px;
+  font-weight: 600;
+  font-size: 18px;
+  color: var(--ink);
+  text-shadow: 0 0 4px rgba(255,255,255,0.8);
+}
+.offer-card__desc {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  padding: 0 16px 16px;
+  font-size: 14px;
+  color: var(--muted);
+  background: linear-gradient(0deg, var(--bg) 10%, transparent);
+  /* truncate text gracefully */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Bottom navigation dock (mobile) */
+bottom-dock {
+}
+.bottom-dock {
+  position: fixed; bottom: 0; left: 0; right: 0; z-index: 50;
+  display: flex; justify-content: space-around;
+  padding: 4px env(safe-area-inset-right) calc(4px + env(safe-area-inset-bottom)) env(safe-area-inset-left);
+  background: var(--card);
+  box-shadow: 0 -2px 10px rgba(0,0,0,0.08);
+}
+.dock-btn {
+  flex: 1; 
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  background: none; border: 0;
+  padding: 6px 0;
+  font-size: 10px; line-height: 1;
+  color: var(--ink);
+}
+.dock-btn span {
+  width: 24px; height: 24px;
+  margin-bottom: 2px;
+  background: currentColor;
+  mask-repeat: no-repeat; mask-position: center; mask-size: contain;
+}
+/* Ikony docka za pomocą mask-image (SVG data URI) */
+.dock-home span {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 12l9-9 9 9v9h-6v-6h-6v6H3z"/></svg>');
+}
+.dock-quote span {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M6.6 10.8a15 15 0 0 0 6.6 6.6l2.2-2.2a1 1 0 0 1 1.1-.2 11.4 11.4 0 0 0 3.5 1.6 1 1 0 0 1 1 1v3.5a1 1 0 0 1-1 1A17.5 17.5 0 0 1 2 6a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .6 3.5 1 1 0 0 1-.2 1.1z"/></svg>');
+}
+.dock-menu span {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 6h18M3 12h18M3 18h18" stroke="black" stroke-width="2" stroke-linecap="round"/></svg>');
+}
+/* Wyróżnienie środkowego przycisku (Wyceń) */
+.dock-btn.dock-quote {
+  flex: 1.4;
+  transform: translateY(-8px);
+}
+.dock-btn em { font-style: normal; }
+
+/* Neon fullscreen menu overlay */
+.neon {
+  position: fixed; inset: 0;
+  display: none;
+  align-items: center; justify-content: center;
+  background: rgba(0,0,0,0.8);
+  backdrop-filter: blur(12px);
+}
+.neon.is-open { display: flex; }
+.neon__inner {
+  background: var(--card);
+  color: var(--ink);
+  padding: 32px;
+  border-radius: var(--r, 16px);
+  box-shadow: 0 0 0 4px hsl(var(--accent-hue) 90% 60% / 0.8);
+  max-height: 90vh;
+  overflow: auto;
+  min-width: min(90vw, 400px);
+  position: relative;
+}
+.neon__nav a {
+  display: block;
+  padding: 8px 0;
+  color: inherit;
+  text-decoration: none;
+}
+.neon__close {
+  position: absolute; top: 16px; right: 16px;
+  background: none; border: 0;
+  font-size: 32px; line-height: 1;
+  color: inherit;
+}
+
+/* Ebook theme adjustments: max content width, justified text */
+:root[data-theme="ebook"] body {
+  background: var(--bg);
+  color: var(--ink);
+}
+:root[data-theme="ebook"] .content {
+  max-width: 68ch;
+  margin-inline: auto;
+  line-height: 1.75;
+}
+:root[data-theme="ebook"] p,
+:root[data-theme="ebook"] li {
+  text-align: justify;
+}
+
+/* --- Utilities & Animations --- */
+
+/* Utility class to hide elements (used for dock when footer visible) */
+.is-hidden { display: none !important; }
+
+/* Fade-slide animation: elements appear with upward movement */
+.fade-slide {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+.fade-slide.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Shimmer effect (for loading placeholders or accents) */
+.shimmer {
+  background: linear-gradient(90deg, rgba(255,255,255,0.0) 0%, rgba(255,255,255,0.3) 50%, rgba(255,255,255,0.0) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+@keyframes shimmer {
+  0%   { background-position: -100% 0; }
+  100% { background-position: 100% 0; }
 }

--- a/assets/js/kras-ui.js
+++ b/assets/js/kras-ui.js
@@ -1,222 +1,351 @@
-(function(){
+(() => {
   'use strict';
   const doc = document.documentElement;
-  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const rIC = window.requestIdleCallback || function(cb){ setTimeout(cb,1); };
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const rIC = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
 
-  function initTheme(){
+  // Inicjalizacja motywu: obsługa przełącznika trybów i zapamiętywanie wyboru
+  function initTheme() {
     const btn = document.getElementById('theme-toggle');
-    if(!btn) return;
-    const themes = ['system','dark','light','ebook'];
+    if (!btn) return;
+    const themes = ['system', 'dark', 'light', 'ebook'];
     let current = localStorage.getItem('kras-theme') || 'system';
+    // Element dymka z podpowiedzią
     const hint = document.createElement('span');
     hint.className = 'theme-hint';
     hint.hidden = true;
     btn.after(hint);
-    function apply(t){
+    function applyTheme(theme) {
       doc.removeAttribute('data-theme');
-      if(t !== 'system') doc.setAttribute('data-theme', t);
-      btn.setAttribute('aria-pressed', t !== 'system');
+      if (theme !== 'system') doc.setAttribute('data-theme', theme);
+      // aria-pressed = true jeśli wybrano konkretny motyw (nie systemowy)
+      btn.setAttribute('aria-pressed', theme !== 'system');
     }
-    function showHint(txt){
-      if(!txt) return;
-      hint.textContent = txt;
+    function showHint(text) {
+      if (!text) return;
+      hint.textContent = text;
       hint.hidden = false;
-      requestAnimationFrame(()=>hint.classList.add('show'));
-      setTimeout(()=>{hint.classList.remove('show');hint.hidden=true;},3000);
+      requestAnimationFrame(() => hint.classList.add('show'));
+      // Schowanie dymka po 3 sekundach
+      setTimeout(() => {
+        hint.classList.remove('show');
+        hint.hidden = true;
+      }, 3000);
     }
-    apply(current);
-    btn.addEventListener('click', ()=>{
-      current = themes[(themes.indexOf(current)+1)%themes.length];
+    // Ustaw motyw początkowy (z localStorage lub systemowy)
+    applyTheme(current);
+    // Obsługa kliknięcia przełącznika: zmiana motywu cyklicznie
+    btn.addEventListener('click', () => {
+      current = themes[(themes.indexOf(current) + 1) % themes.length];
       localStorage.setItem('kras-theme', current);
-      apply(current);
+      applyTheme(current);
+      // Wyświetlenie podpowiedzi jaki motyw ustawiono (napisy z CMS dla różnych motywów)
       const hints = (window.KRAS_STRINGS && window.KRAS_STRINGS.theme_hints) || {};
-      showHint(hints[current]);
+      showHint(hints[current] || '');
     });
   }
 
-  function gateAnimations(){
-    if(reduce) return;
-    rIC(()=>doc.classList.remove('no-motion'));
+  // Zdjęcie klasy .no-motion po załadowaniu (umożliwia animacje, jeśli motion nie zredukowany)
+  function gateAnimations() {
+    if (reduceMotion) return;
+    rIC(() => doc.classList.remove('no-motion'));
   }
 
-  function initDock(){
-    const quote = document.querySelector('.dock-quote');
+  // Inicjalizacja dolnego docka: obsługa przycisków oraz ukrywanie przy stopce
+  function initDock() {
+    const quoteBtn = document.querySelector('.dock-quote');
     const menuBtn = document.getElementById('dock-menu');
-    quote && quote.addEventListener('click', e=>{
-      const t = document.getElementById('kontakt');
-      t && t.scrollIntoView({behavior:'smooth'});
+    // Kliknięcie "Wyceń" przewija do sekcji kontakt (stopki) i pokazuje dymek how-to
+    quoteBtn?.addEventListener('click', () => {
+      document.getElementById('kontakt')?.scrollIntoView({ behavior: 'smooth' });
       showHowTo();
     });
-    menuBtn && menuBtn.addEventListener('click', openMenu);
+    // Kliknięcie "Menu" otwiera neon menu
+    menuBtn?.addEventListener('click', openMenu);
+    // Ukrywanie docka, gdy stopka (kontakt) jest widoczna
+    const dock = document.querySelector('.bottom-dock');
+    const footer = document.querySelector('.site-footer');
+    if (dock && footer && 'IntersectionObserver' in window) {
+      const obs = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting) dock.classList.add('is-hidden');
+        else dock.classList.remove('is-hidden');
+      });
+      obs.observe(footer);
+    }
   }
 
-  let neon, lastFocus;
-  function buildMenu(){
-    const nav = neon.querySelector('.neon__nav');
-    nav.innerHTML = '';
-    const src = document.getElementById('site-nav');
-    if(src && src.children.length){
-      nav.innerHTML = src.innerHTML;
-    }else if(window.KRAS_NAV && window.KRAS_NAV.items){
+  let neonMenuEl = null;
+  let lastFocus = null;
+  // Funkcja uzupełniająca dane w neon menu (linki, języki)
+  function buildMenu() {
+    const navContainer = neonMenuEl.querySelector('.neon__nav');
+    navContainer.innerHTML = '';
+    // Jeśli w #site-nav są już elementy (mega menu zbudowane), klonujemy je
+    const sourceNav = document.getElementById('site-nav');
+    if (sourceNav && sourceNav.children.length) {
+      navContainer.innerHTML = sourceNav.innerHTML;
+    } else if (window.KRAS_NAV && window.KRAS_NAV.items) {
+      // W przeciwnym razie budujemy listę z konfiguracji KRAS_NAV
       const ul = document.createElement('ul');
-      window.KRAS_NAV.items.forEach(it=>{
+      window.KRAS_NAV.items.forEach(item => {
         const li = document.createElement('li');
         const a = document.createElement('a');
-        a.href = it.href;
-        a.textContent = it.label;
+        a.href = item.href;
+        a.textContent = item.label;
         li.appendChild(a);
         ul.appendChild(li);
       });
-      nav.appendChild(ul);
+      navContainer.appendChild(ul);
     }
-    const langs = neon.querySelector('.neon__langs');
-    if(langs){
-      langs.innerHTML = '';
-      const langData = (window.KRAS_NAV && window.KRAS_NAV.langs) || [];
-      langData.forEach(l=>{
+    // Sekcja linków językowych
+    const langsContainer = neonMenuEl.querySelector('.neon__langs');
+    if (langsContainer) {
+      langsContainer.innerHTML = '';
+      const langs = (window.KRAS_NAV && window.KRAS_NAV.langs) || [];
+      langs.forEach(l => {
         const a = document.createElement('a');
         a.href = l.href;
         a.innerHTML = `<img src="${l.flag}" alt="" width="16" height="12"> ${l.label}`;
-        langs.appendChild(a);
+        langsContainer.appendChild(a);
       });
     }
   }
-  function trap(e){
-    if(e.key === 'Escape'){ closeMenu(); return; }
-    if(e.key !== 'Tab') return;
-    const focusables = neon.querySelectorAll('a,button');
-    if(!focusables.length) return;
-    const first = focusables[0];
-    const last = focusables[focusables.length-1];
-    if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
-    else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+  // Pułapka focusu w menu (zamykanie Esc, obsługa Tab w ramach modala)
+  function trapFocus(e) {
+    if (e.key === 'Escape') { closeMenu(); return; }
+    if (e.key !== 'Tab') return;
+    const focusable = neonMenuEl.querySelectorAll('a, button');
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault(); last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault(); first.focus();
+    }
   }
-  function openMenu(){
-    if(!neon) return;
+  // Funkcja otwierająca neon menu
+  function openMenu() {
+    if (!neonMenuEl) return;
     buildMenu();
-    neon.hidden = false;
-    neon.classList.add('is-open');
+    neonMenuEl.hidden = false;
+    neonMenuEl.classList.add('is-open');
     lastFocus = document.activeElement;
-    document.addEventListener('keydown', trap);
-    const f = neon.querySelector('a,button');
-    f && f.focus();
+    document.addEventListener('keydown', trapFocus);
+    // Ustaw fokus na pierwszy link w menu po otwarciu
+    const firstFocusable = neonMenuEl.querySelector('a, button');
+    firstFocusable?.focus();
   }
-  function closeMenu(){
-    if(!neon) return;
-    neon.classList.remove('is-open');
-    neon.hidden = true;
-    document.removeEventListener('keydown', trap);
-    lastFocus && lastFocus.focus();
+  // Funkcja zamykająca neon menu
+  function closeMenu() {
+    if (!neonMenuEl) return;
+    neonMenuEl.classList.remove('is-open');
+    neonMenuEl.hidden = true;
+    document.removeEventListener('keydown', trapFocus);
+    // Przywrócenie fokusu na ostatnio aktywny element przed otwarciem menu
+    lastFocus?.focus();
   }
-  function initNeonMenu(){
-    neon = document.getElementById('neon-menu');
-    if(!neon) return;
-    neon.addEventListener('click', e=>{ if(e.target === neon) closeMenu(); });
-    const closeBtn = neon.querySelector('.neon__close');
-    closeBtn && closeBtn.addEventListener('click', closeMenu);
+  // Inicjalizacja neon menu: dodanie obsługi zamykania po kliknięciu tła i przycisku
+  function initNeonMenu() {
+    neonMenuEl = document.getElementById('neon-menu');
+    if (!neonMenuEl) return;
+    // Kliknięcie poza menu (w tło) – zamyka
+    neonMenuEl.addEventListener('click', (e) => {
+      if (e.target === neonMenuEl) closeMenu();
+    });
+    const closeBtn = neonMenuEl.querySelector('.neon__close');
+    closeBtn?.addEventListener('click', closeMenu);
   }
 
-  function initOfferReveal(){
+  // Animacja sekcji oferty (split-hero) podczas scrollowania – płynne odsłanianie kafelków
+  function initOfferReveal() {
     const host = document.getElementById('offer-reveal');
-    if(!host) return;
+    if (!host) return;
     const sticky = host.querySelector('.split-hero__sticky');
     const rail = host.querySelector('.split-hero__rail');
-    if(matchMedia('(prefers-reduced-motion: reduce)').matches){
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      // Jeśli użytkownik ogranicza animacje – pokaż wszystko od razu
       host.style.setProperty('--p', 1);
-      if(rail) rail.style.pointerEvents='auto';
+      if (rail) rail.style.pointerEvents = 'auto';
       return;
     }
-    const calc=()=>{
-      const r = host.getBoundingClientRect();
+    // Oblicz progres przewinięcia sekcji (p from 0 to 1)
+    const calcProgress = () => {
+      const rect = host.getBoundingClientRect();
       const full = (host.offsetHeight - sticky.offsetHeight) || 1;
-      const passed = Math.min(Math.max(-r.top,0), full);
-      const p = Math.min(Math.max(passed/full,0),1);
+      const scrolled = Math.min(Math.max(-rect.top, 0), full);
+      const p = Math.min(Math.max(scrolled / full, 0), 1);
       host.style.setProperty('--p', p.toFixed(4));
-      if(rail) rail.style.pointerEvents = p>0.15 ? 'auto' : 'none';
+      if (rail) rail.style.pointerEvents = (p > 0.15 ? 'auto' : 'none');
     };
-    let ticking=false;
-    const onScroll=()=>{ if(ticking) return; ticking=true; requestAnimationFrame(()=>{ ticking=false; calc(); }); };
-    const io=new IntersectionObserver(e=>{
-      if(e[0].isIntersecting){ addEventListener('scroll', onScroll, {passive:true}); addEventListener('resize', onScroll); calc(); }
-      else { removeEventListener('scroll', onScroll); removeEventListener('resize', onScroll); }
+    // Throttle scroll events using requestAnimationFrame
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => { ticking = false; calcProgress(); });
+    };
+    // Observer uruchamiający nasłuchiwanie scrolla gdy sekcja pojawi się w viewport
+    const io = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        calcProgress();
+      } else {
+        window.removeEventListener('scroll', onScroll);
+        window.removeEventListener('resize', onScroll);
+      }
     });
     io.observe(host);
   }
 
-  function equalizeCards(){
+  // Wyrównanie wysokości kafelków (np. w gridzie USP czy floty) za pomocą ResizeObserver
+  function equalizeCards() {
     const sets = document.querySelectorAll('.cards[data-equalize]');
-    if(!sets.length) return;
-    const ro = new ResizeObserver(entries=>{
-      entries.forEach(entry=>{
+    if (!sets.length) return;
+    const ro = new ResizeObserver(entries => {
+      entries.forEach(entry => {
         const wrap = entry.target;
-        if(window.matchMedia('(max-width:599px)').matches){
-          wrap.querySelectorAll('.card > .pad').forEach(p=>p.style.minHeight='');
+        const pads = wrap.querySelectorAll('.card > .pad');
+        if (window.matchMedia('(max-width: 599px)').matches) {
+          // Na mobile – reset wysokości (stacking, więc auto dopasowanie)
+          pads.forEach(p => p.style.minHeight = '');
           return;
         }
-        const pads = [...wrap.querySelectorAll('.card > .pad')];
-        let max=0,min=Infinity;
-        pads.forEach(p=>{const h=p.offsetHeight;max=Math.max(max,h);min=Math.min(min,h);});
-        if(max-min>8){pads.forEach(p=>p.style.minHeight=max+'px');}
-        else{pads.forEach(p=>p.style.minHeight='');}
+        // Na większych ekranach: wyrównaj min-wysokość do najwyższej karty
+        let max = 0, min = Infinity;
+        pads.forEach(p => {
+          const h = p.offsetHeight;
+          max = Math.max(max, h);
+          min = Math.min(min, h);
+        });
+        if (max - min > 8) {
+          pads.forEach(p => p.style.minHeight = max + 'px');
+        } else {
+          pads.forEach(p => p.style.minHeight = '');
+        }
       });
     });
-    sets.forEach(set=>ro.observe(set));
+    sets.forEach(set => ro.observe(set));
   }
 
-  let hideHowto;
-  function showHowTo(){
+  // Mechanizm wyświetlania dymka "Jak to działa"
+  let howtoTimeout;
+  function showHowTo() {
     const box = document.getElementById('howto');
-    if(!box || !box.hidden) return;
+    if (!box || !box.hidden) return;
     box.hidden = false;
+    // Pokazuj punkty listy po kolei
     const steps = box.querySelectorAll('li');
-    steps.forEach(li=>li.hidden=true);
-    let i=0; function step(){ if(i<steps.length){ steps[i].hidden=false; i++; setTimeout(step,800); } }
-    step();
-    function close(){ box.hidden=true; document.removeEventListener('keydown', esc); box.removeEventListener('click', close); clearTimeout(hideHowto); }
-    function esc(e){ if(e.key==='Escape') close(); }
-    document.addEventListener('keydown', esc);
-    box.addEventListener('click', close);
-    hideHowto = setTimeout(close,6000);
+    steps.forEach(li => (li.hidden = true));
+    let i = 0;
+    (function revealStep() {
+      if (i < steps.length) {
+        steps[i].hidden = false;
+        i++;
+        setTimeout(revealStep, 800);
+      }
+    })();
+    // Funkcje zamykające dymek
+    function closeBubble() {
+      box.hidden = true;
+      document.removeEventListener('keydown', onEsc);
+      box.removeEventListener('click', closeBubble);
+      clearTimeout(howtoTimeout);
+    }
+    function onEsc(e) {
+      if (e.key === 'Escape') closeBubble();
+    }
+    document.addEventListener('keydown', onEsc);
+    box.addEventListener('click', closeBubble);
+    // Automatyczne schowanie po 6 sekundach
+    howtoTimeout = setTimeout(closeBubble, 6000);
   }
-  function initHowTo(){
-    const cta = document.querySelector('.hero-cta .btn.primary');
-    cta && cta.addEventListener('click', ()=>{ showHowTo(); });
+  // Inicjalizacja dymka "Jak to działa" – powiązanie z głównym CTA
+  function initHowTo() {
+    const primaryCta = document.querySelector('.hero-cta .btn.primary');
+    primaryCta?.addEventListener('click', () => { showHowTo(); });
   }
 
-  function lazyBackgrounds(){
+  // Leniwe wczytanie tła canvas (animacja patyczków) po pewnym czasie bezczynności
+  function lazyBackgrounds() {
     const canvas = document.getElementById('bg-canvas');
-    if(!canvas || reduce) return;
-    rIC(()=>{
+    if (!canvas || reduceMotion) return;
+    rIC(() => {
       canvas.hidden = false;
       const ctx = canvas.getContext('2d');
-      let w=0,h=0,rafId,last=0;
-      function resize(){ w=canvas.width=window.innerWidth; h=canvas.height=window.innerHeight; }
-      resize(); window.addEventListener('resize', resize);
-      const sticks = Array.from({length:30},()=>({x:Math.random()*w,y:Math.random()*h,l:20+Math.random()*40,vx:(Math.random()-.5)*0.3,vy:(Math.random()-.5)*0.3}));
-      function draw(ts){
-        if(document.hidden){ rafId=requestAnimationFrame(draw); return; }
-        if(ts-last<33){ rafId=requestAnimationFrame(draw); return; }
-        last=ts;
-        ctx.clearRect(0,0,w,h);
-        ctx.strokeStyle='rgba(255,145,64,.15)';
-        sticks.forEach(s=>{
-          s.x+=s.vx; s.y+=s.vy;
-          if(s.x<0||s.x>w) s.vx*=-1;
-          if(s.y<0||s.y>h) s.vy*=-1;
+      let w = 0, h = 0, last = 0, rafId;
+      function resize() { 
+        w = canvas.width = window.innerWidth; 
+        h = canvas.height = window.innerHeight; 
+      }
+      resize();
+      window.addEventListener('resize', resize);
+      // Tworzenie "patyczków" – losowe linie poruszające się po ekranie
+      const sticks = Array.from({ length: 30 }, () => ({
+        x: Math.random() * w, 
+        y: Math.random() * h, 
+        l: 20 + Math.random() * 40,
+        vx: (Math.random() - 0.5) * 0.3,
+        vy: (Math.random() - 0.5) * 0.3
+      }));
+      function draw(timestamp) {
+        if (document.hidden) {
+          rafId = requestAnimationFrame(draw);
+          return;
+        }
+        if (timestamp - last < 33) {
+          // ~30fps throttle
+          rafId = requestAnimationFrame(draw);
+          return;
+        }
+        last = timestamp;
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(255,145,64,0.15)';  // kolor (pomarańcz) z transparentnością
+        sticks.forEach(s => {
+          s.x += s.vx; s.y += s.vy;
+          // odbijanie od krawędzi
+          if (s.x < 0 || s.x > w) s.vx *= -1;
+          if (s.y < 0 || s.y > h) s.vy *= -1;
           ctx.beginPath();
           ctx.moveTo(s.x, s.y);
-          ctx.lineTo(s.x+s.l*s.vx*5, s.y+s.l*s.vy*5);
+          ctx.lineTo(s.x + s.l * s.vx * 5, s.y + s.l * s.vy * 5);
           ctx.stroke();
         });
-        rafId=requestAnimationFrame(draw);
+        rafId = requestAnimationFrame(draw);
       }
-      rafId=requestAnimationFrame(draw);
-      document.addEventListener('visibilitychange',()=>{ if(document.hidden) cancelAnimationFrame(rafId); else rafId=requestAnimationFrame(draw); });
+      rafId = requestAnimationFrame(draw);
+      // Wstrzymanie animacji gdy strona nieaktywna (przy przejściu do innej karty)
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) cancelAnimationFrame(rafId);
+        else rafId = requestAnimationFrame(draw);
+      });
     });
   }
 
-  function init(){
+  // Leniwe osadzenie mapy kierunków (iframe) gdy dojdziemy do sekcji
+  function initMapEmbed() {
+    const iframe = document.querySelector('.routes-map');
+    if (!iframe) return;
+    const dataSrc = iframe.getAttribute('data-src');
+    if (!dataSrc) return;
+    // Jeśli przeglądarka obsługuje native lazy (loading="lazy"), zostawiamy atrybut
+    if ('loading' in HTMLIFrameElement.prototype) {
+      // (Iframe już ma loading=lazy w HTML, nie trzeba nic robić)
+      return;
+    }
+    // Dla starszych – używamy IntersectionObserver do nadania src
+    const mapObserver = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        iframe.src = dataSrc;
+        mapObserver.disconnect();
+      }
+    }, { rootMargin: '100px' });
+    mapObserver.observe(iframe);
+  }
+
+  // Główna inicjalizacja po załadowaniu DOM
+  function init() {
     initTheme();
     initDock();
     initNeonMenu();
@@ -224,12 +353,16 @@
     equalizeCards();
     initHowTo();
     lazyBackgrounds();
+    initMapEmbed();
     gateAnimations();
+    // Odsłonięcie hero (np. dla fade-in obrazu)
     const hero = document.getElementById('hero');
     hero && hero.classList.add('is-ready');
   }
 
+  // Start po załadowaniu dokumentu
   document.addEventListener('DOMContentLoaded', init);
 
+  // Ujawnienie globalnych funkcji (opcjonalnie, do debug lub wywołań zewnętrznych)
   window.KRASUI = { openMenu, closeMenu, showHowTo };
 })();

--- a/index.html
+++ b/index.html
@@ -1,99 +1,260 @@
-<!DOCTYPE html>
-<html lang="pl" data-theme="light">
+<!doctype html>
+<html lang="{{ page.lang or 'pl' }}" class="no-motion" data-theme="{{ user_preferred_theme or 'system' }}">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Kras-Trans — Ekspresowy transport 3,5 t i TIR • Polska & UE</title>
-  <meta name="description" content="Transport ekspresowy i dedykowany: busy do 3,5 t i TIR. Łódź, Polska, cała UE. 24/7, monitoring GPS, OC przewoźnika." />
-  <link rel="preload" as="video" href="assets/media/hero.mp4" />
-  <link rel="preload" href="assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="assets/css/kras-global.css" as="style" />
-  <link rel="stylesheet" href="assets/css/kras-global.css" media="print" onload="this.media='all'" />
-  <noscript><link rel="stylesheet" href="assets/css/kras-global.css" /></noscript>
+  <meta name="theme-color" content="#ff7a1a" />
+  <title>{{ page.seo_title or page.title or 'Kras-Trans — Transport ekspresowy' }}</title>
+  <meta name="description" content="{{ page.meta_desc or page.lead or 'Transport ekspresowy i dedykowany — Polska & Europa' }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="{{ page.og_title or page.seo_title or page.title }}" />
+  <meta property="og:description" content="{{ page.og_desc or page.meta_desc or page.lead }}" />
+  <meta property="og:image" content="{{ page.og_image or '/assets/media/og-default.jpg' }}" />
+  <meta property="og:url" content="{{ page.url or '/' }}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="{{ page.seo_title or page.title }}" />
+  <meta name="twitter:description" content="{{ page.meta_desc or page.lead }}" />
+  <meta name="twitter:image" content="{{ page.og_image or '/assets/media/og-default.jpg' }}" />
+  <!-- Preload critical assets (fonts, CSS) -->
+  <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="/assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="/assets/css/kras-global.css" as="style" />
+  <link rel="preload" href="/assets/css/kras-ui.css" as="style" />
+  <!-- Asynchronous CSS loading (prevents render-blocking) -->
+  <link rel="stylesheet" href="/assets/css/kras-global.css" media="print" onload="this.media='all'; this.onload=null;" />
+  <link rel="stylesheet" href="/assets/css/kras-ui.css" media="print" onload="this.media='all'; this.onload=null;" />
+  <noscript>
+    <!-- Fallback for no-JS: load CSS normally -->
+    <link rel="stylesheet" href="/assets/css/kras-global.css" />
+    <link rel="stylesheet" href="/assets/css/kras-ui.css" />
+  </noscript>
+  <style>
+    /* Visually hidden utility (for accessibility) */
+    .visually-hidden { position:absolute !important; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); clip-path:inset(50%); white-space:nowrap; border:0; }
+  </style>
+  <script>
+    // Dodanie linków alternatywnych dla różnych języków (hreflang), jeśli dane dostępne w CMS
+    (function(){
+      const data = window.CMS_DATA || {};
+      const { slugKey } = window.CMS_PAGE || {};
+      const map = (data.hreflang || {})[slugKey];
+      if (!map) return;
+      Object.entries(map).forEach(([lang, href]) => {
+        const link = document.createElement('link');
+        link.rel = 'alternate';
+        link.hreflang = (lang === 'ua') ? 'uk' : lang;
+        link.href = href;
+        document.head.appendChild(link);
+      });
+      // x-default link (fallback to PL or EN)
+      const x = document.createElement('link');
+      x.rel = 'alternate';
+      x.hreflang = 'x-default';
+      x.href = map.en || map.pl;
+      document.head.appendChild(x);
+    })();
+  </script>
 </head>
 <body>
+  <!-- Tła dekoracyjne: siatka i animowane patyczki (ukryte do idle) -->
+  <div id="bg-grid" aria-hidden="true"></div>
+  <canvas id="bg-canvas" aria-hidden="true" hidden></canvas>
 
-  <main id="main">
-    <!-- HERO: wideo ma W/H + poster (zero CLS) -->
-    <section class="hero" id="kras-hero" aria-label="Ekspresowy transport 3,5 t i TIR – Polska i UE">
-      <div class="container wrap">
-        <div>
-          <span class="claim" data-cms-key="hero_claim">KOMPLEKSOWE USŁUGI TRANSPORTOWE</span>
-          <h1 data-cms-key="hero_title">Ekspresowy transport busem 3,5 t i TIR – Polska &amp; Europa</h1>
-          <p data-cms-key="hero_desc">Transport ekspresowy i dedykowany door-to-door dla firm i produkcji. Odbiór już dziś.</p>
-          <p>
-            <a class="btn primary" href="#wycena">Wycena 15 min</a>
-            <a class="btn" href="tel:+48793927467">Zadzwoń</a>
+  <!-- HEADER: Nagłówek strony (sticky, przezroczysty z efektem rozmycia tła) -->
+  <header class="site-header">
+    <div class="container header-grid">
+      <!-- Logo firmy -->
+      <a class="brand" href="/">
+        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high" />
+      </a>
+      <!-- Główna nawigacja (uzupełniana dynamicznie) -->
+      <nav id="site-nav" class="nav" hidden aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+      <div class="header-actions">
+        <!-- Przycisk przełączania motywu (jasny/ciemny/e-book) -->
+        <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="{{ strings.theme_toggle or 'Zmień motyw' }}" aria-pressed="false">
+          <span class="sun"></span><span class="moon"></span><span class="paper"></span>
+        </button>
+        <!-- Główny CTA w headerze (np. Wyceń) -->
+        <a class="btn primary btn--shine" href="#kontakt">{{ strings.cta_call or 'Wyceń' }}</a>
+      </div>
+    </div>
+    <!-- Mega Menu (desktop) - uzupełniane przez menu-builder.js -->
+    <div id="mega-root" class="mega" hidden></div>
+  </header>
+
+  <main id="main" class="content" role="main">
+    <!-- HERO SECTION: Duże hero z tłem wideo/obrazkiem, hasłem i CTA -->
+    <section class="hero" id="hero">
+      <div class="container hero-wrap">
+        <div class="hero-copy">
+          <span class="claim">{{ page.claim or 'Kompleksowe usługi transportowe' }}</span>
+          <h1>{{ page.h1 or page.title }}</h1>
+          {% if page.lead %}
+          <p class="lead">{{ page.lead }}</p>
+          {% endif %}
+          <p class="hero-cta">
+            <a class="btn primary" href="#kontakt">{{ strings.hero_cta_primary or 'Wyceń transport teraz' }}</a>
+            <a class="btn" href="tel:{{ (company and company[0].telephone) or '+48793927467' }}">{{ strings.hero_cta_secondary or 'Zadzwoń' }}</a>
           </p>
+          <!-- Dymek "Jak to działa" (pokazywany dynamicznie po kliknięciu CTA "Wyceń") -->
+          <aside class="howto" id="howto" hidden aria-live="polite">
+            <ol>
+              <li>Kliknij „Wyceń transport teraz”.</li>
+              <li>Wpisz trasę i dane ładunku.</li>
+              <li>Wyślij – oddzwonimy i potwierdzimy odbiór.</li>
+            </ol>
+          </aside>
         </div>
-        <video muted loop playsinline preload="none" poster="assets/media/hero-poster.webp" width="1280" height="720">
-          <source src="assets/media/hero.mp4" type="video/mp4" />
-        </video>
+        {% if page.hero_video %}
+          <!-- Tło wideo hero (lazy inicjacja) -->
+          <video class="hero-media" muted loop playsinline preload="none" poster="{{ page.hero_poster or '' }}" width="1680" height="720">
+            <source src="{{ page.hero_video or '/assets/media/hero.mp4' }}" type="video/mp4" />
+          </video>
+        {% elif page.hero_image %}
+          <!-- Tło obrazkowe hero -->
+          <img class="hero-media" src="{{ page.hero_image }}" alt="{{ page.hero_alt or page.h1 }}" width="1680" height="720" loading="eager" fetchpriority="high" />
+        {% endif %}
       </div>
     </section>
 
-    <!-- OFERTA: na mobile przewijanie w poziomie (scroll-snap) -->
-    <section class="section --line">
-      <div class="container text">
-        <h2 data-cms-key="offer_title"></h2>
-      </div>
-      <div class="container cards cards--scroll">
-        <article class="card"><div class="pad"><h3 data-cms-key="offer1_title">Transport krajowy</h3><p data-cms-key="offer1_desc">Szybkie przewozy w Polsce.</p></div></article>
-        <article class="card"><div class="pad"><h3 data-cms-key="offer2_title">Transport międzynarodowy</h3><p data-cms-key="offer2_desc">Obsługa całej Europy.</p></div></article>
-        <article class="card"><div class="pad"><h3 data-cms-key="offer3_title">Transport ekspresowy</h3><p data-cms-key="offer3_desc">Dostawy tego samego dnia.</p></div></article>
-        <article class="card"><div class="pad"><h3 data-cms-key="offer4_title">Transport ADR</h3><p data-cms-key="offer4_desc">Bezpieczny przewóz materiałów niebezpiecznych.</p></div></article>
-        <article class="card"><div class="pad"><h3 data-cms-key="offer5_title">Transport paletowy</h3><p data-cms-key="offer5_desc">Palety EUR/EPAL, winda, wózek.</p></div></article>
-      </div>
-    </section>
-
-    <!-- FAQ: znak zapytania animowany (breathe), respektuje prefers-reduced-motion -->
-    <section class="section --dots" id="faq">
-      <div class="container text">
-        <h2 data-cms-key="faq_title">FAQ – najczęściej zadawane pytania</h2>
-        <div class="faq">
-          <details><summary data-cms-key="faq1_q">Jak szybko zrealizujecie transport?</summary><p data-cms-key="faq1_a">Standardowo 24–48 h, w trybie ekspresowym często tego samego dnia.</p></details>
-          <details><summary data-cms-key="faq2_q">Ile kosztuje przewóz busem 3,5 t?</summary><p data-cms-key="faq2_a">Orientacyjnie od 3,50 zł/km. Wycena online 24/7.</p></details>
-          <details><summary data-cms-key="faq3_q">Skąd startujecie?</summary><p data-cms-key="faq3_a">Łódź i cała Polska — realizujemy transport po UE.</p></details>
-        </div>
-      </div>
-    </section>
-
-    <!-- Kontakt/Wycena -->
-    <section class="section --wave" id="wycena">
-      <div class="container text">
-        <h2 data-cms-key="contact_title">Skontaktuj się z nami</h2>
-        <form class="card" method="post" action="#">
-          <div class="pad">
-            <div class="cards">
-              <label class="card"><div class="pad"><input name="name" type="text" placeholder="Imię i nazwisko" required style="width:100%;padding:12px;border-radius:10px;border:1px solid var(--border)"></div></label>
-              <label class="card"><div class="pad"><input name="phone" type="tel" placeholder="Telefon" required style="width:100%;padding:12px;border-radius:10px;border:1px solid var(--border)"></div></label>
-              <label class="card"><div class="pad"><input name="email" type="email" placeholder="E-mail" required style="width:100%;padding:12px;border-radius:10px;border:1px solid var(--border)"></div></label>
-            </div>
-            <p><textarea name="message" placeholder="Treść zapytania" rows="4" style="width:100%;padding:12px;border-radius:10px;border:1px solid var(--border)"></textarea></p>
-            <p><button class="btn primary" type="submit">Wyślij</button> <a class="btn" href="tel:+48793927467">Zadzwoń</a></p>
+    <!-- OFFER SECTION: Sekcja "Nasza oferta" z kafelkami usług (dynamiczne z CMS) -->
+    <section class="section split-hero split-hero--narrow" id="offer-reveal" data-section="offers" data-style="edge" data-accent="amber" aria-label="{{ strings.offers_aria or 'Nasza oferta' }}">
+      <div class="split-hero__sticky">
+        <div class="split-hero__stack">
+          <!-- Podzielony tytuł sekcji (animacja "heading split") -->
+          <div class="split-hero__title" aria-hidden="true">
+            <span class="title-half title-left">{{ strings.offers_title or 'Nasza oferta' }}</span>
+            <span class="title-half title-right">{{ strings.offers_title or 'Nasza oferta' }}</span>
           </div>
-        </form>
+          <h2 class="visually-hidden">{{ strings.offers_title or 'Nasza oferta' }}</h2>
+          <!-- Lista kafelków ofert (przewijana w poziomie na mobile) -->
+          <div class="split-hero__rail tilt-cards" id="offer-rail" role="list" aria-label="{{ strings.offers_list or 'Usługi (przesuń w bok na telefonie)' }}">
+            <!-- Kafelki usług generowane na podstawie CMS (pętla po elementach "offer") -->
+            {% for service in offers %}
+            <a role="listitem" class="offer-card" href="{{ service.url }}">
+              {% if service.media %}
+              <img src="{{ service.media }}" alt="" width="{{ service.img_w or 1280 }}" height="{{ service.img_h or 720 }}" loading="lazy" decoding="async" />
+              {% endif %}
+              <span class="offer-card__title">{{ service.title }}</span>
+              {% if service.desc or service.lead %}
+              <span class="offer-card__desc">{{ service.desc or service.lead }}</span>
+              {% endif %}
+            </a>
+            {% endfor %}
+            <!-- (Przykładowy statyczny kafelek jako wzór) -->
+            <!-- 
+            <a role="listitem" class="offer-card" href="/pl/trasy-ekspresowe/">
+              <img src="/assets/media/offer-1.jpg" alt="" width="1280" height="720" />
+              <span class="offer-card__title">Transport ekspresowy</span>
+              <span class="offer-card__desc">Dedykowany transport 24/7 na terenie całej UE</span>
+            </a>
+            -->
+          </div>
+        </div>
+      </div>
+      <!-- Dekoracyjny separator falisty między sekcjami (animacja morph) -->
+      <div class="sep sep--morph" data-morph="wave-2" aria-hidden="true"></div>
+    </section>
+
+    <!-- MAP SECTION: Sekcja "Kierunki" z osadzoną mapą tras -->
+    <section class="section" id="kierunki" data-section="kierunki" data-style="glass" aria-label="{{ strings.routes_title or 'Kierunki' }}">
+      <div class="container text">
+        <h2>{{ strings.routes_title or 'Kierunki' }}</h2>
+      </div>
+      <div class="container">
+        <div class="iframe-wrap" style="aspect-ratio:16/9;">
+          <!-- Osadzona mapa kierunków (ładowna leniwie) -->
+          <iframe class="routes-map" title="Mapa kierunków" 
+                  width="560" height="315" 
+                  loading="lazy" 
+                  src="" data-src="/assets/media/mapa-kierunkow-kras-trans.html" 
+                  sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer">
+          </iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ SECTION: Najczęściej zadawane pytania -->
+    <section class="section faq" id="faq" aria-label="{{ strings.faq_title or 'Najczęściej zadawane pytania' }}">
+      <div class="container">
+        <h2>{{ strings.faq_title or 'FAQ' }}</h2>
+        <!-- Lista pytań i odpowiedzi generowana z CMS (każdy element jako <details>) -->
+        {% for item in faq %}
+        <details>
+          <summary>{{ item.question }}</summary>
+          <div>{{ item.answer }}</div>
+        </details>
+        {% endfor %}
+        <!-- Przykładowy element FAQ: -->
+        <!-- 
+        <details>
+          <summary>Jak szybko realizowane są transporty?</summary>
+          <div>Nasza firma świadczy usługi ekspresowe, większość transportów realizujemy w ciągu 24 godzin od zlecenia.</div>
+        </details>
+        -->
       </div>
     </section>
   </main>
 
-  <!-- Dock mobilny -->
-  <nav class="bottom-bar" aria-label="Skróty">
-    <a href="#wycena">📦<span>Wycena</span></a>
-    <a href="#faq">❓<span>FAQ</span></a>
-    <a href="tel:+48793927467">📞<span>Telefon</span></a>
-    <a href="#kras-hero">⬆️<span>Góra</span></a>
-    <a href="/pl/transport-miedzynarodowy/">🌍<span>EU</span></a>
+  <!-- FOOTER: Stopka strony z danymi kontaktowymi (id="kontakt") -->
+  <footer class="site-footer" id="kontakt">
+    <div class="container footer-grid">
+      <div>
+        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" width="120" height="28" alt="Kras-Trans" loading="lazy" />
+        <div class="company">
+          <strong>{{ company[0].name or 'Kras-Trans' }}</strong><br/>
+          {% if company and company[0].street_address %}{{ company[0].street_address }}{% endif %}{% if company and company[0].postal_code %}, {{ company[0].postal_code }}{% endif %}{% if company and company[0].city %} {{ company[0].city }}{% endif %}<br/>
+          <a href="tel:{{ (company and company[0].telephone) or '+48793927467' }}">{{ (company and company[0].telephone) or '+48 793 927 467' }}</a><br/>
+          <a href="mailto:{{ (company and company[0].email) or 'biuro@kras-trans.pl' }}">{{ (company and company[0].email) or 'biuro@kras-trans.pl' }}</a>
+        </div>
+      </div>
+      <!-- Linki w stopce (uzupełniane z CMS/nav) -->
+      <nav class="footer-links" aria-label="{{ strings.nav_footer or 'Nawigacja w stopce' }}"></nav>
+    </div>
+    <div class="container">
+      <small>© {{ (now or '')[:4] or '' }} {{ company[0].name or 'Kras-Trans' }} — Ekspresowy transport 24/7</small>
+    </div>
+  </footer>
+
+  <!-- BOTTOM NAV: Dolny pasek nawigacji mobilnej -->
+  <nav class="bottom-dock" aria-label="Szybka nawigacja">
+    <a class="dock-btn dock-home" href="/{{ page.lang or 'pl' }}/" aria-label="{{ strings.home or 'Start' }}">
+      <span></span><em>Start</em>
+    </a>
+    <a class="dock-btn dock-quote" href="#kontakt" aria-label="{{ strings.quote or 'Wyceń' }}">
+      <span></span><em>Wyceń</em>
+    </a>
+    <button class="dock-btn dock-menu" id="dock-menu" aria-label="{{ strings.menu or 'Menu' }}">
+      <span></span><em>Menu</em>
+    </button>
   </nav>
 
-    <footer class="site-footer">
-      <div class="container footer-grid" id="footer-columns"></div>
-      <div class="container"><small data-cms-key="footer_copy">© 2025 Kras-Trans • ul. Trzcinowa 14/11, 91-495 Łódź • <a href="tel:+48793927467">+48 793 927 467</a></small></div>
-    </footer>
+  <!-- NEON MENU: Pełnoekranowe menu nawigacyjne (overlay) -->
+  <div id="neon-menu" class="neon" hidden aria-modal="true" role="dialog">
+    <div class="neon__inner">
+      <button class="neon__close" aria-label="{{ strings.close or 'Zamknij' }}">×</button>
+      <!-- Główne linki nawigacyjne (uzupełnia buildMenu() na podstawie #site-nav lub window.KRAS_NAV) -->
+      <nav class="neon__nav" aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+      <!-- Linki językowe (flagi języków) generowane dynamicznie przez buildMenu() -->
+      <div class="neon__langs" aria-label="{{ strings.nav_langs or 'Języki' }}"></div>
+    </div>
+  </div>
 
-    <script src="assets/js/header-loader.js" defer></script>
-    <script src="assets/js/kras-global.js" defer></script>
-    <script src="assets/js/cms-loader.js" defer></script>
-  </body>
-  </html>
+  <!-- SCRIPTS: konfiguracja nawigacji i dołączanie skryptów -->
+  <script>
+    /* Globalna konfiguracja menu z CMS (wstawiana podczas build) */
+    window.KRAS_NAV = {{ nav_cfg | tojson }};
+  </script>
+  <script src="/assets/js/kras-global.js" defer></script>
+  <script src="/assets/js/menu-builder.js" defer></script>
+  <!-- Ładowanie głównego skryptu interfejsu po wczytaniu strony (idle) -->
+  <script>
+    (window.requestIdleCallback || window.setTimeout)(function(){
+      const s = document.createElement('script');
+      s.src = "/assets/js/kras-ui.js";
+      s.defer = true;
+      document.body.appendChild(s);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- overhaul homepage skeleton with async CSS loading, CMS-driven sections, and bottom navigation dock
- add comprehensive UI stylesheet supporting light, dark, and ebook themes with dock and neon menu styles
- implement interactive JS for theme toggling, lazy backgrounds, and responsive menu handling

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ac5131d08333862dc35c0b422be1