### PR TITLE
feat: refresh site layout with new header and footer

### DIFF
--- a/assets/kt.css
+++ b/assets/kt.css
@@ -1,0 +1,83 @@
+/* ====== Theme tokens ====== */
+:root{
+  --brand:#00A3E0; --brand-ink:#003B57;
+  --bg:#fff; --ink:#0f172a; --muted:#6b7280;
+  --surface:color-mix(in srgb, var(--bg) 80%, transparent);
+  --header-alpha:.65; --elev:16px; --radius:12px; --focus:#94caff;
+  --shadow:0 10px 30px rgba(0,0,0,.08); --shadow-strong:0 10px 40px rgba(0,0,0,.16);
+  --maxw:1200px; --nav-h:72px; --z-header:50; --z-panel:49; --z-drawer:60;
+}
+@media (prefers-color-scheme:dark){
+  :root{--bg:#0b1220;--ink:#e5e7eb;--muted:#a3a3a3;--surface:color-mix(in srgb, var(--bg) 65%, transparent);
+    --header-alpha:.35;--focus:#52b6ff;--shadow:0 10px 30px rgba(0,0,0,.6);--shadow-strong:0 10px 40px rgba(0,0,0,.7)}
+}
+html,body{height:100%} body{margin:0;background:var(--bg);color:var(--ink);font:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif;line-height:1.5}
+img,svg{display:block;max-width:100%} a{color:inherit;text-decoration:none} button{font:inherit}
+.container{max-width:var(--maxw);margin-inline:auto;padding-inline:20px}
+
+/* ====== Header ====== */
+.site-header{position:sticky;top:0;inset-inline:0;z-index:var(--z-header);
+  backdrop-filter:saturate(1.2) blur(8px);
+  background:color-mix(in srgb, var(--bg) calc(var(--header-alpha)*100%), transparent);
+  transition:background .25s ease, box-shadow .25s ease, border-color .25s ease;
+  border-bottom:1px solid color-mix(in srgb, var(--ink) 10%, transparent)}
+.site-header.is-scrolled{background:var(--bg);box-shadow:var(--shadow)}
+.navbar{display:flex;align-items:center;justify-content:space-between;height:var(--nav-h)}
+.brand{display:inline-flex;align-items:center;gap:.6rem;font-weight:800;letter-spacing:.2px}
+.brand__logo{width:36px;height:36px;border-radius:8px;background:var(--brand);display:grid;place-items:center;color:#fff;font-weight:900;box-shadow:var(--shadow)}
+.brand__name{font-size:1.1rem}
+.nav{display:flex;align-items:center;gap:24px}
+.nav__list{display:flex;align-items:center;gap:10px;margin:0;padding:0;list-style:none}
+.nav__btn{position:relative;display:inline-flex;align-items:center;gap:.35rem;padding:.6rem .8rem;border-radius:10px;border:none;background:transparent;color:inherit;cursor:pointer}
+.nav__btn .chev{inline-size:.85rem;block-size:.85rem;transition:transform .2s ease}
+.nav__btn[aria-expanded="true"] .chev{transform:rotate(180deg)}
+.nav__btn:hover{background:color-mix(in srgb, var(--brand) 10%, transparent)}
+.actions{display:flex;align-items:center;gap:10px}
+.cta{display:inline-flex;align-items:center;gap:.5rem;border-radius:999px;padding:.55rem 1rem;background:var(--brand);color:#fff;font-weight:700;box-shadow:var(--shadow-strong)}
+.cta:hover{filter:brightness(.95)}
+.icon-btn{display:inline-grid;place-items:center;width:40px;height:40px;border-radius:10px;border:1px solid color-mix(in srgb, var(--ink) 12%, transparent);background:transparent;cursor:pointer}
+.hamburger{display:none}
+
+/* Lang panel */
+.lang{position:relative}
+.lang__panel{position:absolute;right:0;top:calc(100% + 8px);background:var(--bg);border:1px solid color-mix(in srgb, var(--ink) 12%, transparent);border-radius:12px;box-shadow:var(--shadow);padding:8px;min-width:220px;display:none}
+.lang[aria-expanded="true"] .lang__panel{display:block}
+.lang__list{list-style:none;margin:0;padding:4px}
+.lang__list li a{display:block;padding:.5rem .6rem;border-radius:8px}
+.lang__list li a:hover{background:color-mix(in srgb, var(--brand) 10%, transparent)}
+
+/* Mega panels */
+.panels{position:relative}
+.panel{position:absolute;left:0;right:0;top:100%;transform:translateY(12px);display:none;background:var(--bg);border-top:1px solid color-mix(in srgb, var(--ink) 10%, transparent);box-shadow:var(--shadow);padding-block:20px;z-index:var(--z-panel)}
+.panel.is-open{display:block}
+.panel__grid{display:grid;gap:24px;grid-template-columns:repeat(4,minmax(0,1fr))}
+.panel__col h4{margin:0 0 8px;font-size:.95rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+.panel__link{display:flex;align-items:center;gap:.6rem;padding:.5rem;border-radius:10px}
+.panel__link:hover{background:color-mix(in srgb, var(--brand) 8%, transparent)}
+.chip{font-size:.75rem;padding:.1rem .4rem;border-radius:6px;border:1px solid color-mix(in srgb, var(--ink) 12%, transparent);color:var(--muted)}
+
+/* Drawer (mobile) */
+.drawer{position:fixed;inset:0;background:var(--bg);z-index:var(--z-drawer);transform:translateY(-100%);transition:transform .25s ease;display:flex;flex-direction:column}
+.drawer.is-open{transform:translateY(0)}
+.drawer__head{display:flex;align-items:center;justify-content:space-between;padding:14px 20px;border-bottom:1px solid color-mix(in srgb, var(--ink) 12%, transparent)}
+.drawer__body{overflow:auto;padding:10px 20px 24px}
+.acc{border-top:1px solid color-mix(in srgb, var(--ink) 12%, transparent)}
+.acc__btn{width:100%;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:14px 0;border:none;background:transparent;color:inherit;font-weight:600}
+.acc__panel{display:none;padding:0 0 10px 0}
+.acc__panel.is-open{display:block}
+.sublist{list-style:none;margin:0;padding:0}
+.sublist a{display:block;padding:10px;border-radius:10px}
+.sublist a:hover{background:color-mix(in srgb, var(--brand) 10%, transparent)}
+
+/* Content helpers */
+.hero{padding:40px 0}
+.lead{white-space:pre-line} /* zachowaj \n z arkusza */
+.content{padding:40px 0 80px}
+
+/* Footer */
+.site-footer{padding:32px 0;border-top:1px solid color-mix(in srgb, var(--ink) 12%, transparent);opacity:.9}
+.foot-row{display:flex;justify-content:space-between;align-items:center;gap:16px}
+.foot-nav a{margin-left:16px}
+
+/* Responsive */
+@media (max-width:991px){.nav{display:none}.hamburger{display:inline-grid}.panel{display:none !important}.cta{padding:.55rem .9rem}}

--- a/assets/kt.js
+++ b/assets/kt.js
@@ -1,0 +1,62 @@
+const qs=(s,c=document)=>c.querySelector(s), qsa=(s,c=document)=>Array.from(c.querySelectorAll(s));
+const header=qs('#header');
+
+// sticky zmiana tła (opcjonalnie, jeśli masz sentinel w hero – można pominąć)
+function onScroll(){ header && header.classList.toggle('is-scrolled', window.scrollY>20); }
+onScroll(); window.addEventListener('scroll', onScroll, {passive:true});
+
+// mega-panels
+let opened=null;
+function closePanels(){ qsa('.nav__btn[data-panel]').forEach(b=>b.setAttribute('aria-expanded','false'));
+  qsa('.panel').forEach(p=>{p.classList.remove('is-open');p.hidden=true}); opened=null; }
+function openPanel(id){ closePanels(); const btn=qs(`.nav__btn[data-panel="${id}"]`), panel=qs(`#panel-${id}`);
+  if(!btn||!panel) return; btn.setAttribute('aria-expanded','true'); panel.hidden=false; panel.classList.add('is-open'); opened=id; }
+qsa('.nav__btn[data-panel]').forEach(btn=>{
+  const id=btn.dataset.panel;
+  btn.addEventListener('click',()=> opened===id ? closePanels() : openPanel(id));
+  btn.addEventListener('mouseenter',()=> window.matchMedia('(min-width: 992px)').matches && openPanel(id));
+});
+document.addEventListener('click',e=>{ if(header && !header.contains(e.target)) closePanels(); });
+header && header.addEventListener('mouseleave',()=> window.matchMedia('(min-width: 992px)').matches && closePanels());
+
+// drawer mobile
+const drawer=qs('#drawer'), hamburger=qs('#hamburger'), drawerClose=qs('#drawerClose');
+function lockBody(b){document.body.style.overflow=b?'hidden':''}
+function openDrawer(){ if(!drawer||!hamburger) return; drawer.hidden=false; drawer.classList.add('is-open'); hamburger.setAttribute('aria-expanded','true'); lockBody(true); closePanels(); }
+function closeDrawer(){ if(!drawer||!hamburger) return; drawer.classList.remove('is-open'); hamburger.setAttribute('aria-expanded','false'); lockBody(false); setTimeout(()=>drawer.hidden=true,200); }
+hamburger && hamburger.addEventListener('click', openDrawer);
+drawerClose && drawerClose.addEventListener('click', closeDrawer);
+qsa('.acc').forEach(acc=>{
+  const btn=qs('.acc__btn',acc), panel=qs('.acc__panel',acc);
+  btn && btn.addEventListener('click',()=>{ const open=btn.getAttribute('aria-expanded')==='true'; btn.setAttribute('aria-expanded', String(!open)); panel && panel.classList.toggle('is-open', !open); });
+});
+
+// języki
+const langWrap=qs('[data-lang]');
+if(langWrap){
+  const langBtn=langWrap.querySelector('button');
+  langBtn && langBtn.addEventListener('click', ()=>{
+    const expanded=langWrap.getAttribute('aria-expanded')==='true';
+    langWrap.setAttribute('aria-expanded', String(!expanded));
+    langBtn.setAttribute('aria-expanded', String(!expanded));
+  });
+  document.addEventListener('click', e=>{ if(!langWrap.contains(e.target)){ langWrap.setAttribute('aria-expanded','false'); langBtn && langBtn.setAttribute('aria-expanded','false'); }});
+}
+
+// theme
+const themeBtn=qs('#themeToggle'), root=document.documentElement;
+function applyTheme(t){ root.setAttribute('data-theme', t); }
+const saved=localStorage.getItem('theme'); if(saved) applyTheme(saved);
+themeBtn && themeBtn.addEventListener('click', ()=>{
+  const cur=root.getAttribute('data-theme')||'auto';
+  const next=cur==='dark'?'light':(cur==='light'?'auto':'dark');
+  applyTheme(next); localStorage.setItem('theme', next);
+});
+
+// --- LEAD FIX: zamień **bold** i \n na <br> bez zmiany generatora ---
+qsa('.lead').forEach(el=>{
+  const raw = el.innerHTML || el.textContent || '';
+  const withBr = raw.replace(/\\n/g,'<br>');
+  const withBold = withBr.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
+  if(withBold !== raw) el.innerHTML = withBold;
+});

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>404 - Nie znaleziono</title>
+  <link rel="stylesheet" href="/assets/kt.css">
+</head>
+<body>
+<header class="site-header" id="header">
+  <div class="container navbar">
+    <a class="brand" href="/" aria-label="Strona główna">
+      <span class="brand__logo" aria-hidden="true">K</span>
+      <span class="brand__name">Kras-Trans</span>
+    </a>
+
+    <!-- Desktop nav -->
+    <nav class="nav" aria-label="Główna nawigacja">
+      <ul class="nav__list" role="menubar" aria-label="Główne pozycje">
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="services">
+            Usługi
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="industries">
+            Dla firm
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="resources">
+            Zasoby
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/pl/o-firmie/">O nas</a></li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/pl/flota/">Flota</a></li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/pl/blog/">Blog</a></li>
+      </ul>
+    </nav>
+
+    <!-- Actions -->
+    <div class="actions">
+      <div class="lang" data-lang aria-expanded="false">
+        <button class="icon-btn" aria-haspopup="true" aria-expanded="false" aria-controls="lang-panel" title="Języki">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M4 5h16M4 12h16M4 19h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
+        <div id="lang-panel" class="lang__panel" role="menu" aria-label="Wybierz język">
+          <ul class="lang__list">
+            <li><a href="/pl/" role="menuitem">🇵🇱 Polski</a></li>
+            <li><a href="/en/" role="menuitem">🇬🇧 English</a></li>
+            <li><a href="/de/" role="menuitem">🇩🇪 Deutsch</a></li>
+            <li><a href="/fr/" role="menuitem">🇫🇷 Français</a></li>
+            <li><a href="/it/" role="menuitem">🇮🇹 Italiano</a></li>
+            <li><a href="/ru/" role="menuitem">🇷🇺 Русский</a></li>
+            <li><a href="/ua/" role="menuitem">🇺🇦 Українська</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <button id="themeToggle" class="icon-btn" aria-label="Przełącz motyw">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path id="themeIcon" d="M12 3a9 9 0 100 18 7 7 0 010-18z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+
+      <a href="#quote" class="cta">Wycena</a>
+
+      <button class="icon-btn hamburger" id="hamburger" aria-expanded="false" aria-controls="drawer" aria-label="Menu">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Mega panels (desktop) -->
+  <div class="panels">
+    <div class="panel" id="panel-services" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Transport</h4>
+          <a class="panel__link" href="/pl/transport-ekspresowy/"><strong>Ekspres bus 3,5 t</strong> <span class="chip">Same day</span></a>
+          <a class="panel__link" href="/pl/tir/"><strong>Transport TIR (FTL/LTL)</strong></a>
+          <a class="panel__link" href="/pl/przeprowadzki-b2b/"><strong>Przeprowadzki B2B</strong></a>
+          <a class="panel__link" href="/pl/adr/"><strong>ADR*</strong> <span class="chip">po potwierdzeniu</span></a>
+        </div>
+        <div class="panel__col">
+          <h4>Spedycja</h4>
+          <a class="panel__link" href="#"><strong>Stałe trasy dla firm</strong></a>
+          <a class="panel__link" href="#"><strong>Planowanie i konsolidacja</strong></a>
+          <a class="panel__link" href="#"><strong>Fulfillment & cross-dock</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Obsługiwane kierunki</h4>
+          <a class="panel__link" href="#"><strong>Polska</strong></a>
+          <a class="panel__link" href="#"><strong>Niemcy</strong></a>
+          <a class="panel__link" href="#"><strong>Francja</strong></a>
+          <a class="panel__link" href="#"><strong>Benelux & Włochy</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Szybkie akcje</h4>
+          <a class="panel__link" href="#quote"><strong>Wyceń transport</strong></a>
+          <a class="panel__link" href="/pl/kontakt/"><strong>Kontakt</strong></a>
+          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" id="panel-industries" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Branże</h4>
+          <a class="panel__link" href="#"><strong>E-commerce & 3PL</strong></a>
+          <a class="panel__link" href="#"><strong>Automotive</strong></a>
+          <a class="panel__link" href="#"><strong>Retail & FMCG</strong></a>
+          <a class="panel__link" href="#"><strong>High-tech</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Use cases</h4>
+          <a class="panel__link" href="#"><strong>JIT / linie produkcyjne</strong></a>
+          <a class="panel__link" href="#"><strong>Zwroty & reverse</strong></a>
+          <a class="panel__link" href="#"><strong>Event logistics</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Dokumenty</h4>
+          <a class="panel__link" href="#"><strong>Wzór zlecenia</strong></a>
+          <a class="panel__link" href="#"><strong>Warunki współpracy</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Kontakt B2B</h4>
+          <a class="panel__link" href="#quote"><strong>Stała umowa / cennik</strong></a>
+          <a class="panel__link" href="/pl/kontakt/"><strong>Zostaw brief</strong></a>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" id="panel-resources" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Materiały</h4>
+          <a class="panel__link" href="/pl/blog/"><strong>Blog</strong></a>
+          <a class="panel__link" href="/pl/case-studies/"><strong>Case studies</strong></a>
+          <a class="panel__link" href="#"><strong>Poradniki</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Narzędzia</h4>
+          <a class="panel__link" href="#"><strong>Kalkulator objętości</strong></a>
+          <a class="panel__link" href="#quote"><strong>Wycena online</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Wsparcie</h4>
+          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
+          <a class="panel__link" href="/pl/kontakt/"><strong>Kontakt</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Informacje</h4>
+          <a class="panel__link" href="/pl/o-firmie/"><strong>O firmie</strong></a>
+          <a class="panel__link" href="/pl/flota/"><strong>Flota</strong></a>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- Drawer (mobile) -->
+<div class="drawer" id="drawer" hidden>
+  <div class="drawer__head">
+    <div class="brand"><span class="brand__logo">K</span><span class="brand__name">Kras-Trans</span></div>
+    <button class="icon-btn" id="drawerClose" aria-label="Zamknij menu">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+    </button>
+  </div>
+  <div class="drawer__body">
+    <nav aria-label="Menu mobilne">
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Usługi
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="/pl/transport-ekspresowy/">Ekspres bus 3,5 t</a></li>
+            <li><a href="/pl/tir/">Transport TIR (FTL/LTL)</a></li>
+            <li><a href="/pl/przeprowadzki-b2b/">Przeprowadzki B2B</a></li>
+            <li><a href="/pl/adr/">ADR*</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Dla firm
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="#">Branże</a></li>
+            <li><a href="#">JIT / produkcja</a></li>
+            <li><a href="#">Warunki współpracy</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Zasoby
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="/pl/blog/">Blog</a></li>
+            <li><a href="#">Case studies</a></li>
+            <li><a href="#faq">FAQ</a></li>
+          </ul>
+        </div>
+      </div>
+      <a class="sublist" href="/pl/o-firmie/" style="display:block;padding:14px 0">O nas</a>
+      <a class="sublist" href="/pl/flota/" style="display:block;padding:14px 0">Flota</a>
+      <a class="sublist" href="/pl/blog/" style="display:block;padding:14px 0">Blog</a>
+
+      <div style="padding:16px 0;display:flex;gap:10px">
+        <a class="cta" href="#quote" style="flex:1;justify-content:center">Wycena</a>
+        <a class="icon-btn" href="tel:+48793927467" aria-label="Zadzwoń">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.86 19.86 0 0 1-3.07-8.63A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.12.89.31 1.76.57 2.6a2 2 0 0 1-.45 2.11L8 9a16 16 0 0 0 6 6l.57-.22a2 2 0 0 1 2.11.45c.84.26 1.71.45 2.6.57A2 2 0 0 1 22 16.92z" stroke="currentColor" stroke-width="2"/></svg>
+        </a>
+      </div>
+    </nav>
+  </div>
+</div>
+
+<main class="content">
+  <div class="container" style="padding:40px 0;text-align:center">
+    <h1>404 - Nie znaleziono</h1>
+    <p>Przepraszamy, strona nie istnieje.</p>
+    <p><a href="/" class="cta">Wróć na stronę główną</a></p>
+  </div>
+</main>
+
+<footer class="site-footer">
+  <div class="container foot-row">
+    <div>© Kras-Trans</div>
+    <nav class="foot-nav">
+      <a href="/pl/kontakt/">Kontakt</a>
+      <a href="/pl/o-firmie/">O firmie</a>
+      <a href="/pl/licenses-insurance/">Licencje & ubezpieczenia</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer src="/assets/kt.js"></script>
+</body>
+</html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -29,6 +29,7 @@
     <link rel="stylesheet" href="/assets/css/kras-global.css">
     <link rel="stylesheet" href="/assets/css/kras-ui.css">
   </noscript>
+  <link rel="stylesheet" href="/assets/kt.css">
   <style>.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0}</style>
   <script>
     // zakładamy: window.CMS_PAGE = { slugKey:'…', lang:'pl' }
@@ -60,26 +61,226 @@
   <div id="bg-grid" aria-hidden="true"></div>
   <canvas id="bg-canvas" aria-hidden="true" hidden></canvas>
 
-  <!-- HEADER (sticky, przezroczysty, backdrop) -->
-  <header class="site-header">
-    <div class="container header-grid">
-      <a class="brand" href="/">
-        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high">
-      </a>
+  <header class="site-header" id="header">
+  <div class="container navbar">
+    <a class="brand" href="/" aria-label="Strona główna">
+      <span class="brand__logo" aria-hidden="true">K</span>
+      <span class="brand__name">Kras-Trans</span>
+    </a>
 
-      <nav id="site-nav" class="nav" hidden aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+    <!-- Desktop nav -->
+    <nav class="nav" aria-label="Główna nawigacja">
+      <ul class="nav__list" role="menubar" aria-label="Główne pozycje">
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="services">
+            Usługi
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="industries">
+            Dla firm
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none">
+          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="resources">
+            Zasoby
+            <svg class="chev" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+        </li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/{{ page.lang or 'pl' }}/o-firmie/">O nas</a></li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/{{ page.lang or 'pl' }}/flota/">Flota</a></li>
+        <li role="none"><a class="nav__btn" role="menuitem" href="/{{ page.lang or 'pl' }}/blog/">Blog</a></li>
+      </ul>
+    </nav>
 
-      <div class="header-actions">
-        <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="{{ strings.theme_toggle or 'Zmień motyw' }}">
-          <span class="sun"></span><span class="moon"></span><span class="paper"></span>
+    <!-- Actions -->
+    <div class="actions">
+      <div class="lang" data-lang aria-expanded="false">
+        <button class="icon-btn" aria-haspopup="true" aria-expanded="false" aria-controls="lang-panel" title="Języki">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M4 5h16M4 12h16M4 19h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
         </button>
-        <a class="btn primary btn--shine" href="#kontakt">{{ strings.cta_call or 'Wyceń' }}</a>
+        <div id="lang-panel" class="lang__panel" role="menu" aria-label="Wybierz język">
+          <ul class="lang__list">
+            <li><a href="/pl/" role="menuitem">🇵🇱 Polski</a></li>
+            <li><a href="/en/" role="menuitem">🇬🇧 English</a></li>
+            <li><a href="/de/" role="menuitem">🇩🇪 Deutsch</a></li>
+            <li><a href="/fr/" role="menuitem">🇫🇷 Français</a></li>
+            <li><a href="/it/" role="menuitem">🇮🇹 Italiano</a></li>
+            <li><a href="/ru/" role="menuitem">🇷🇺 Русский</a></li>
+            <li><a href="/ua/" role="menuitem">🇺🇦 Українська</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <button id="themeToggle" class="icon-btn" aria-label="Przełącz motyw">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path id="themeIcon" d="M12 3a9 9 0 100 18 7 7 0 010-18z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+
+      <a href="#quote" class="cta">Wycena</a>
+
+      <button class="icon-btn hamburger" id="hamburger" aria-expanded="false" aria-controls="drawer" aria-label="Menu">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Mega panels (desktop) -->
+  <div class="panels">
+    <div class="panel" id="panel-services" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Transport</h4>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/transport-ekspresowy/"><strong>Ekspres bus 3,5 t</strong> <span class="chip">Same day</span></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/tir/"><strong>Transport TIR (FTL/LTL)</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/przeprowadzki-b2b/"><strong>Przeprowadzki B2B</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/adr/"><strong>ADR*</strong> <span class="chip">po potwierdzeniu</span></a>
+        </div>
+        <div class="panel__col">
+          <h4>Spedycja</h4>
+          <a class="panel__link" href="#"><strong>Stałe trasy dla firm</strong></a>
+          <a class="panel__link" href="#"><strong>Planowanie i konsolidacja</strong></a>
+          <a class="panel__link" href="#"><strong>Fulfillment & cross-dock</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Obsługiwane kierunki</h4>
+          <a class="panel__link" href="#"><strong>Polska</strong></a>
+          <a class="panel__link" href="#"><strong>Niemcy</strong></a>
+          <a class="panel__link" href="#"><strong>Francja</strong></a>
+          <a class="panel__link" href="#"><strong>Benelux & Włochy</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Szybkie akcje</h4>
+          <a class="panel__link" href="#quote"><strong>Wyceń transport</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/kontakt/"><strong>Kontakt</strong></a>
+          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
+        </div>
       </div>
     </div>
 
-    <!-- MEGA-MENU (desktop; nad hero; zasilane przez menu-builder.js) -->
-    <div id="mega-root" class="mega" hidden></div>
-  </header>
+    <div class="panel" id="panel-industries" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Branże</h4>
+          <a class="panel__link" href="#"><strong>E-commerce & 3PL</strong></a>
+          <a class="panel__link" href="#"><strong>Automotive</strong></a>
+          <a class="panel__link" href="#"><strong>Retail & FMCG</strong></a>
+          <a class="panel__link" href="#"><strong>High-tech</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Use cases</h4>
+          <a class="panel__link" href="#"><strong>JIT / linie produkcyjne</strong></a>
+          <a class="panel__link" href="#"><strong>Zwroty & reverse</strong></a>
+          <a class="panel__link" href="#"><strong>Event logistics</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Dokumenty</h4>
+          <a class="panel__link" href="#"><strong>Wzór zlecenia</strong></a>
+          <a class="panel__link" href="#"><strong>Warunki współpracy</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Kontakt B2B</h4>
+          <a class="panel__link" href="#quote"><strong>Stała umowa / cennik</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/kontakt/"><strong>Zostaw brief</strong></a>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" id="panel-resources" hidden>
+      <div class="container panel__grid">
+        <div class="panel__col">
+          <h4>Materiały</h4>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/blog/"><strong>Blog</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/case-studies/"><strong>Case studies</strong></a>
+          <a class="panel__link" href="#"><strong>Poradniki</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Narzędzia</h4>
+          <a class="panel__link" href="#"><strong>Kalkulator objętości</strong></a>
+          <a class="panel__link" href="#quote"><strong>Wycena online</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Wsparcie</h4>
+          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/kontakt/"><strong>Kontakt</strong></a>
+        </div>
+        <div class="panel__col">
+          <h4>Informacje</h4>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/o-firmie/"><strong>O firmie</strong></a>
+          <a class="panel__link" href="/{{ page.lang or 'pl' }}/flota/"><strong>Flota</strong></a>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- Drawer (mobile) -->
+<div class="drawer" id="drawer" hidden>
+  <div class="drawer__head">
+    <div class="brand"><span class="brand__logo">K</span><span class="brand__name">Kras-Trans</span></div>
+    <button class="icon-btn" id="drawerClose" aria-label="Zamknij menu">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+    </button>
+  </div>
+  <div class="drawer__body">
+    <nav aria-label="Menu mobilne">
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Usługi
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="/{{ page.lang or 'pl' }}/transport-ekspresowy/">Ekspres bus 3,5 t</a></li>
+            <li><a href="/{{ page.lang or 'pl' }}/tir/">Transport TIR (FTL/LTL)</a></li>
+            <li><a href="/{{ page.lang or 'pl' }}/przeprowadzki-b2b/">Przeprowadzki B2B</a></li>
+            <li><a href="/{{ page.lang or 'pl' }}/adr/">ADR*</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Dla firm
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="#">Branże</a></li>
+            <li><a href="#">JIT / produkcja</a></li>
+            <li><a href="#">Warunki współpracy</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="acc">
+        <button class="acc__btn" aria-expanded="false">Zasoby
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
+        <div class="acc__panel">
+          <ul class="sublist">
+            <li><a href="/{{ page.lang or 'pl' }}/blog/">Blog</a></li>
+            <li><a href="#">Case studies</a></li>
+            <li><a href="#faq">FAQ</a></li>
+          </ul>
+        </div>
+      </div>
+      <a class="sublist" href="/{{ page.lang or 'pl' }}/o-firmie/" style="display:block;padding:14px 0">O nas</a>
+      <a class="sublist" href="/{{ page.lang or 'pl' }}/flota/" style="display:block;padding:14px 0">Flota</a>
+      <a class="sublist" href="/{{ page.lang or 'pl' }}/blog/" style="display:block;padding:14px 0">Blog</a>
+
+      <div style="padding:16px 0;display:flex;gap:10px">
+        <a class="cta" href="#quote" style="flex:1;justify-content:center">Wycena</a>
+        <a class="icon-btn" href="tel:+48793927467" aria-label="Zadzwoń">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.86 19.86 0 0 1-3.07-8.63A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.12.89.31 1.76.57 2.6a2 2 0 0 1-.45 2.11L8 9a16 16 0 0 0 6 6l.57-.22a2 2 0 0 1 2.11.45c.84.26 1.71.45 2.6.57A2 2 0 0 1 22 16.92z" stroke="currentColor" stroke-width="2"/></svg>
+        </a>
+      </div>
+    </nav>
+  </div>
+</div>
 
   <main id="main" class="content" role="main">
     <!-- HERO (21:9, bez stałego tła) -->
@@ -163,42 +364,21 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="container footer-grid">
-      <div>
-        <img src="/assets/media/logo-firma-transportowa-kras-trans.png" width="120" height="28" alt="Kras-Trans" loading="lazy">
-        <div class="company">
-          <strong>{{ company[0].name or 'Kras-Trans' }}</strong><br>
-          {% if company and company[0].streetAddress %}{{ company[0].streetAddress }}{% endif %}
-          {% if company and company[0].postalCode %}, {{ company[0].postalCode }}{% endif %}
-          {% if company and company[0].addressLocality %} {{ company[0].addressLocality }}{% endif %}<br>
-          <a href="tel:{{ (company and company[0].telephone) or '+48793927467' }}">{{ (company and company[0].telephone) or '+48 793 927 467' }}</a>
-        </div>
-      </div>
-      <nav class="footer-links" aria-label="{{ strings.nav_footer or 'Nawigacja w stopce' }}"></nav>
-    </div>
-    <div class="container"><small>© {{ (now or '')[:4] or '' }} {{ company[0].name or 'Kras-Trans' }}</small></div>
-  </footer>
-
-  <!-- MOBILE DOCK -->
-  <nav class="bottom-dock" aria-label="Szybka nawigacja">
-    <a class="dock-btn dock-home" href="/{{ (page.lang or 'pl') }}/" aria-label="{{ strings.home or 'Start' }}"><span></span><em>Start</em></a>
-    <a class="dock-btn dock-quote" href="#kontakt" aria-label="{{ strings.quote or 'Wyceń' }}"><span></span><em>Wyceń</em></a>
-    <button class="dock-btn dock-menu" id="dock-menu" aria-label="{{ strings.menu or 'Menu' }}"><span></span><em>Menu</em></button>
-  </nav>
-
-  <!-- NEON MENU (fullscreen) -->
-  <div id="neon-menu" class="neon" hidden aria-modal="true" role="dialog">
-    <div class="neon__inner">
-      <button class="neon__close" aria-label="{{ strings.close or 'Zamknij' }}">×</button>
-      <nav class="neon__nav" aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
-      <div class="neon__langs" aria-label="{{ strings.nav_langs or 'Języki' }}"></div>
-    </div>
+  <div class="container foot-row">
+    <div>© {{ site.name or 'Kras-Trans' }}</div>
+    <nav class="foot-nav">
+      <a href="/{{ page.lang or 'pl' }}/kontakt/">Kontakt</a>
+      <a href="/{{ page.lang or 'pl' }}/o-firmie/">O firmie</a>
+      <a href="/{{ page.lang or 'pl' }}/licenses-insurance/">Licencje & ubezpieczenia</a>
+    </nav>
   </div>
+</footer>
 
   <!-- SKRYPTY -->
   <script>window.KRAS_NAV = {{ nav_cfg|tojson }};</script>
   <script src="/assets/js/kras-global.js" defer></script>
   <script src="/assets/js/menu-builder.js" defer></script>
   <script>(window.requestIdleCallback||window.setTimeout)(function(){var s=document.createElement('script');s.src='/assets/js/kras-ui.js';s.defer=true;document.body.appendChild(s);});</script>
+  <script defer src="/assets/kt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace legacy header with mega-menu navigation and mobile drawer
- add lightweight site footer and global kt.css/kt.js assets
- include new styled 404 page with matching header

## Testing
- `APPS_URL=http://localhost:8000/cms.json APPS_KEY=dummy python tools/build_local.py` *(fails: jinja2.exceptions.UndefinedError: 'strings' is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb1eb6ac83338fb5c942042c60f7