### PR TITLE
Enable markdown descriptions and responsive iframe styling

### DIFF
--- a/assets/kt.css
+++ b/assets/kt.css
@@ -74,6 +74,11 @@ img,svg{display:block;max-width:100%} a{color:inherit;text-decoration:none} butt
 .lead{white-space:pre-line} /* zachowaj \n z arkusza */
 .content{padding:40px 0 80px}
 
+/* Media wrappers */
+.iframe-wrap{aspect-ratio:16/9;min-height:320px}
+.iframe-wrap iframe{width:100%;height:100%;border:0}
+@media (max-width:780px){.iframe-wrap{aspect-ratio:4/3;margin-top:24px}}
+
 /* Footer */
 .site-footer{padding:32px 0;border-top:1px solid color-mix(in srgb, var(--ink) 12%, transparent);opacity:.9}
 .foot-row{display:flex;justify-content:space-between;align-items:center;gap:16px}

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
               {% endif %}
               <span class="offer-card__title">{{ service.title }}</span>
               {% if service.desc or service.lead %}
-              <span class="offer-card__desc">{{ service.desc or service.lead }}</span>
+              <span class="offer-card__desc" data-md>{{ service.desc or service.lead }}</span>
               {% endif %}
             </a>
             {% endfor %}
@@ -146,7 +146,7 @@
             <a role="listitem" class="offer-card" href="/pl/trasy-ekspresowe/">
               <img src="/assets/media/offer-1.jpg" alt="" width="1280" height="720" />
               <span class="offer-card__title">Transport ekspresowy</span>
-              <span class="offer-card__desc">Dedykowany transport 24/7 na terenie całej UE</span>
+              <span class="offer-card__desc" data-md>Dedykowany transport 24/7 na terenie całej UE</span>
             </a>
             -->
           </div>
@@ -162,12 +162,11 @@
         <h2>{{ strings.routes_title or 'Kierunki' }}</h2>
       </div>
       <div class="container">
-        <div class="iframe-wrap" style="aspect-ratio:16/9;">
+        <div class="iframe-wrap">
           <!-- Osadzona mapa kierunków (ładowna leniwie) -->
-          <iframe class="routes-map" title="Mapa kierunków" 
-                  width="560" height="315" 
-                  loading="lazy" 
-                  src="" data-src="/assets/media/mapa-kierunkow-kras-trans.html" 
+          <iframe class="routes-map" title="Mapa kierunków"
+                  loading="lazy"
+                  src="" data-src="/assets/media/mapa-kierunkow-kras-trans.html"
                   sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer">
           </iframe>
         </div>

--- a/templates/homs.html
+++ b/templates/homs.html
@@ -137,7 +137,7 @@
               {% endif %}
               <span class="offer-card__title">{{ service.title }}</span>
               {% if service.desc or service.lead %}
-              <span class="offer-card__desc">{{ service.desc or service.lead }}</span>
+              <span class="offer-card__desc" data-md>{{ service.desc or service.lead }}</span>
               {% endif %}
             </a>
             {% endfor %}
@@ -146,7 +146,7 @@
             <a role="listitem" class="offer-card" href="/pl/trasy-ekspresowe/">
               <img src="/assets/media/offer-1.jpg" alt="" width="1280" height="720" />
               <span class="offer-card__title">Transport ekspresowy</span>
-              <span class="offer-card__desc">Dedykowany transport 24/7 na terenie całej UE</span>
+              <span class="offer-card__desc" data-md>Dedykowany transport 24/7 na terenie całej UE</span>
             </a>
             -->
           </div>
@@ -162,12 +162,11 @@
         <h2>{{ strings.routes_title or 'Kierunki' }}</h2>
       </div>
       <div class="container">
-        <div class="iframe-wrap" style="aspect-ratio:16/9;">
+        <div class="iframe-wrap">
           <!-- Osadzona mapa kierunków (ładowna leniwie) -->
-          <iframe class="routes-map" title="Mapa kierunków" 
-                  width="560" height="315" 
-                  loading="lazy" 
-                  src="" data-src="/assets/media/mapa-kierunkow-kras-trans.html" 
+          <iframe class="routes-map" title="Mapa kierunków"
+                  loading="lazy"
+                  src="" data-src="/assets/media/mapa-kierunkow-kras-trans.html"
                   sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer">
           </iframe>
         </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -274,7 +274,7 @@
               <a role="listitem" class="offer-card" href="{{ url }}">
                 {% if it.media %}<img src="{{ it.media }}" alt="" width="{{ it.img_w or 1280 }}" height="{{ it.img_h or 720 }}" loading="lazy" decoding="async">{% endif %}
                 <span class="offer-card__title">{{ it.h1 or it.title or it.seo_title or it.slug }}</span>
-                {% if it.lead or it.desc or it.meta_desc %}<span class="offer-card__desc">{{ it.lead or it.desc or it.meta_desc }}</span>{% endif %}
+                {% if it.lead or it.desc or it.meta_desc %}<span class="offer-card__desc" data-md>{{ it.lead or it.desc or it.meta_desc }}</span>{% endif %}
               </a>
             {% endfor %}
           </div>
@@ -295,11 +295,10 @@
     <section class="section" id="kierunki" data-section="kierunki" data-style="glass">
       <div class="container text"><h2>{{ STR.routes_title or T.routes_title }}</h2></div>
       <div class="container">
-        <div class="iframe-wrap" style="aspect-ratio:16/9">
+        <div class="iframe-wrap">
           <iframe class="routes-map" title="Mapa kierunków" loading="lazy"
                   src="/assets/media/mapa-kierunkow-kras-trans.html"
-                  sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"
-                  style="width:100%;height:100%;border:0"></iframe>
+                  sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- allow Markdown formatting in offer block descriptions by adding `data-md`
- centralize iframe map styling with responsive aspect ratios and mobile spacing

## Testing
- `tools/test_footer.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1def1320883339f3928f36de3d40e