### PR TITLE
feat: add disappearing button navigation effect

### DIFF
--- a/assets/css/kras-ui.css
+++ b/assets/css/kras-ui.css
@@ -359,3 +359,22 @@ bottom-dock {
   0%   { background-position: -100% 0; }
   100% { background-position: 100% 0; }
 }
+
+/* Efekt znikającego przycisku po kliknięciu */
+a[data-disappear],
+button[data-disappear] {
+  transition: opacity 0.14s ease, transform 0.14s ease;
+  will-change: opacity, transform;
+}
+a[data-disappear].bye,
+button[data-disappear].bye {
+  opacity: 0;
+  transform: scale(0.92);
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  a[data-disappear],
+  button[data-disappear] {
+    transition: none;
+  }
+}

--- a/assets/js/kras-ui.js
+++ b/assets/js/kras-ui.js
@@ -267,6 +267,32 @@
     primaryCta?.addEventListener('click', () => { showHowTo(); });
   }
 
+  // Efekt znikania przycisku przed przejściem na nową stronę
+  function initDisappear() {
+    document.addEventListener('click', e => {
+      const el = e.target.closest('a[data-disappear],button[data-disappear]');
+      if (!el) return;
+      if (el.dataset.firing) { e.preventDefault(); return; }
+      el.dataset.firing = '1';
+      const rect = el.getBoundingClientRect();
+      el.style.width = rect.width + 'px';
+      el.style.height = rect.height + 'px';
+      el.classList.add('bye');
+      el.setAttribute('aria-disabled', 'true');
+      const url = el.getAttribute('href') || el.dataset.href || '#';
+      const target = el.getAttribute('target');
+      const delay = parseInt(el.dataset.delay || '140', 10);
+      e.preventDefault();
+      window.setTimeout(() => {
+        if (target === '_blank') {
+          window.open(url, '_blank', 'noopener');
+        } else {
+          window.location.assign(url);
+        }
+      }, delay);
+    });
+  }
+
   // Leniwe wczytanie tła canvas (animacja patyczków) po pewnym czasie bezczynności
   function lazyBackgrounds() {
     const canvas = document.getElementById('bg-canvas');
@@ -354,6 +380,7 @@
     initHowTo();
     lazyBackgrounds();
     initMapEmbed();
+    initDisappear();
     gateAnimations();
     // Odsłonięcie hero (np. dla fade-in obrazu)
     const hero = document.getElementById('hero');

--- a/assets/kt.css
+++ b/assets/kt.css
@@ -86,3 +86,7 @@ img,svg{display:block;max-width:100%} a{color:inherit;text-decoration:none} butt
 
 /* Responsive */
 @media (max-width:991px){.nav{display:none}.hamburger{display:inline-grid}.panel{display:none !important}.cta{padding:.55rem .9rem}}
+
+a[data-disappear],button[data-disappear]{transition:opacity .14s ease,transform .14s ease;will-change:opacity,transform}
+a[data-disappear].bye,button[data-disappear].bye{opacity:0;transform:scale(.92);pointer-events:none}
+@media(prefers-reduced-motion:reduce){a[data-disappear],button[data-disappear]{transition:none}}

--- a/assets/kt.js
+++ b/assets/kt.js
@@ -60,3 +60,21 @@ qsa('.lead').forEach(el=>{
   const withBold = withBr.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
   if(withBold !== raw) el.innerHTML = withBold;
 });
+
+// efekt znikania przycisku i nawigacja
+document.addEventListener('click',e=>{
+  const el=e.target.closest('a[data-disappear],button[data-disappear]');
+  if(!el) return;
+  if(el.dataset.firing){ e.preventDefault(); return; }
+  el.dataset.firing='1';
+  const rect=el.getBoundingClientRect();
+  el.style.width=rect.width+'px';
+  el.style.height=rect.height+'px';
+  el.classList.add('bye');
+  el.setAttribute('aria-disabled','true');
+  const url=el.getAttribute('href')||el.dataset.href||'#';
+  const target=el.getAttribute('target');
+  const delay=parseInt(el.dataset.delay||'140',10);
+  e.preventDefault();
+  window.setTimeout(()=>{target==='_blank'?window.open(url,'_blank','noopener'):window.location.assign(url);},delay);
+});


### PR DESCRIPTION
## Summary
- add CSS utility for disappearing buttons
- trigger button fade-out before navigation via JS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a1f2ccb3488333bab293edf59be450