### PR TITLE
Introduce SEO macros and data-driven templates

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+{% if site_url and ('localhost' in site_url or 'preview' in site_url) %}
+User-agent: *
+Disallow: /
+# X-Robots-Tag: noindex
+{% else %}
+User-agent: *
+Allow: /
+Sitemap: {{ site_url }}/sitemap.xml
+{% endif %}

--- a/templates/_macros/seo.html
+++ b/templates/_macros/seo.html
@@ -1,0 +1,149 @@
+{% macro brand(company) -%}
+  {%- if company is defined and company and company[0].name -%}
+    {{ company[0].name }}
+  {%- else -%}
+    Kras-Trans
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro canon(page) -%}
+  {%- set lang = (page.lang if page.lang is defined and page.lang else 'pl') -%}
+  {%- set slug = page.slugKey or page.slug or 'home' -%}
+  {{ page.canonical_path if page.canonical_path is defined and page.canonical_path else '/' ~ lang ~ '/' ~ (slug != 'home' and (slug ~ '/') or '') }}
+{%- endmacro %}
+
+{% macro seo_title(page, brand) -%}
+  {{ page.seo_title if page.seo_title is defined and page.seo_title else page.title if page.title is defined and page.title else page.h1 if page.h1 is defined and page.h1 else brand ~ ' — Transport' }}
+{%- endmacro %}
+
+{% macro meta_desc(page) -%}
+  {%- if page.meta_desc is defined and page.meta_desc -%}
+    {{ page.meta_desc }}
+  {%- elif page.lead is defined and page.lead -%}
+    {{ page.lead | truncate(160, True, '') }}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro hreflang_links(slugKey, hreflang) -%}
+  {%- set mapping = hreflang[slugKey] if hreflang is defined and slugKey in hreflang else {} -%}
+  {%- for code, url in mapping.items() -%}
+    <link rel="alternate" hreflang="{{ 'uk' if code == 'ua' else code }}" href="{{ url }}">
+  {%- endfor -%}
+  {%- if mapping.en or mapping.pl -%}
+    <link rel="alternate" hreflang="x-default" href="{{ mapping.en or mapping.pl }}">
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro breadcrumbs(page, pages) -%}
+  {%- set ns = namespace(crumbs=[]) -%}
+  {%- set lang = page.lang if page.lang is defined and page.lang else 'pl' -%}
+  {%- set parent = page.parentSlug if page.parentSlug is defined else None -%}
+  {%- for i in range(10) -%}
+    {%- if parent -%}
+      {%- set p = pages|selectattr('slug','equalto',parent)|selectattr('lang','equalto',lang)|first -%}
+      {%- if p -%}
+        {%- set ns.crumbs = [{'label': p.title or p.h1 or p.slug, 'href': '/' ~ lang ~ '/' ~ (p.slug and (p.slug ~ '/') or '')}] + ns.crumbs -%}
+        {%- set parent = p.parentSlug if p.parentSlug is defined else None -%}
+      {%- else -%}
+        {%- set parent = None -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- set current_label = page.h1 or page.title or (page.slug if page.slug is defined else '') -%}
+  {%- set ns.crumbs = ns.crumbs + [{'label': current_label, 'href': '/' ~ lang ~ '/' ~ (page.slug if page.slug is defined and page.slug else '')}] -%}
+  {{ ns.crumbs }}
+{%- endmacro %}
+
+{% macro image_alt(page) -%}
+  {{ page.hero_alt if page.hero_alt is defined and page.hero_alt else page.h1 if page.h1 is defined else '' }}
+{%- endmacro %}
+
+{% macro outlinks(page, pages, limit_min, limit_max, suggest, anchors) -%}
+  {%- set lang = page.lang if page.lang is defined and page.lang else 'pl' -%}
+  {%- set res = [] -%}
+  {%- set added = [] -%}
+  {%- set anchor_list = anchors.split(',') if anchors is defined and anchors else [] -%}
+  {%- set idx = 0 -%}
+  {%- if suggest is defined and suggest -%}
+    {%- for sk in suggest.split(',') -%}
+      {%- set sk = sk|trim -%}
+      {%- set p = pages|selectattr('slugKey','equalto',sk)|selectattr('lang','equalto',lang)|first -%}
+      {%- if p and p.slug != page.slug -%}
+        {%- set anchor = anchor_list[idx] if anchor_list|length > idx else p.title or p.h1 or p.slug -%}
+        {%- set res = res + [{'href':'/'~lang~'/'~(p.slug or sk)~'/', 'anchor':anchor}] -%}
+        {%- set added = added + [p.slug] -%}
+        {%- set idx = idx + 1 -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+  {%- set siblings = pages|selectattr('parentSlug','equalto',page.parentSlug)|selectattr('lang','equalto',lang)|list if pages is defined else [] -%}
+  {%- for p in siblings -%}
+    {%- if res|length < limit_max -%}
+      {%- if p.slug != page.slug and p.slug not in added -%}
+        {%- set anchor = anchor_list[idx] if anchor_list|length > idx else p.title or p.h1 or p.slug -%}
+        {%- set res = res + [{'href':'/'~lang~'/'~p.slug~'/', 'anchor':anchor}] -%}
+        {%- set added = added + [p.slug] -%}
+        {%- set idx = idx + 1 -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- if res|length < limit_min -%}
+    {%- set services = pages|selectattr('type','equalto','service')|selectattr('lang','equalto',lang)|sort(attribute='order')|list -%}
+    {%- for p in services -%}
+      {%- if res|length < limit_min -%}
+        {%- if p.slug != page.slug and p.slug not in added -%}
+          {%- set anchor = anchor_list[idx] if anchor_list|length > idx else p.title or p.h1 or p.slug -%}
+          {%- set res = res + [{'href':'/'~lang~'/'~p.slug~'/', 'anchor':anchor}] -%}
+          {%- set added = added + [p.slug] -%}
+          {%- set idx = idx + 1 -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+  {{ res[:limit_max] }}
+{%- endmacro %}
+
+{% macro structured(page, company, blocks) -%}
+  {%- set data = [] -%}
+  {%- set lang = page.lang if page.lang is defined and page.lang else 'pl' -%}
+  {%- set slug = page.slug if page.slug is defined else '' -%}
+  {%- set url = page.canonical_path if page.canonical_path is defined and page.canonical_path else '/'~lang~'/'~(slug and slug~'/' or '') -%}
+  {%- if slug in ('', 'home') -%}
+    {%- set website = {'@context':'https://schema.org','@type':'WebSite','url':url,'potentialAction':{'@type':'SearchAction','target':url~'?q={search_term_string}','query-input':'required name=search_term_string'}} -%}
+    {%- set data = data + [website] -%}
+  {%- endif -%}
+  {%- if company is defined and company and company[0] -%}
+    {%- set c = company[0] -%}
+    {%- set org = {'@context':'https://schema.org','@type':'LocalBusiness','name':c.name,'telephone':c.telephone,'email':c.email,'address':{'@type':'PostalAddress','streetAddress':c.streetAddress,'addressLocality':c.addressLocality,'postalCode':c.postalCode,'addressCountry':c.addressCountry}} -%}
+    {%- set data = data + [org] -%}
+  {%- endif -%}
+  {%- if pages is defined -%}
+    {%- set bc = breadcrumbs(page, pages) -%}
+  {%- else -%}
+    {%- set bc = [] -%}
+  {%- endif -%}
+  {%- if bc -%}
+    {%- set items = [] -%}
+    {%- for b in bc -%}
+      {%- set items = items + [{'@type':'ListItem','position':loop.index,'name':b.label,'item':b.href}] -%}
+    {%- endfor -%}
+    {%- set data = data + [{'@context':'https://schema.org','@type':'BreadcrumbList','itemListElement':items}] -%}
+  {%- endif -%}
+  {%- if page.type is defined and page.type == 'service' -%}
+    {%- set svc = {'@context':'https://schema.org','@type':'Service','name':page.h1 or page.title} -%}
+    {%- set data = data + [svc] -%}
+  {%- endif -%}
+  {%- set faqs = blocks|selectattr('block','equalto','faq')|list if blocks is defined else [] -%}
+  {%- if faqs -%}
+    {%- set faq_items = [] -%}
+    {%- for f in faqs -%}
+      {%- set faq_items = faq_items + [{'@type':'Question','name':f.title,'acceptedAnswer':{'@type':'Answer','text':f.body_md}}] -%}
+    {%- endfor -%}
+    {%- set data = data + [{'@context':'https://schema.org','@type':'FAQPage','mainEntity':faq_items}] -%}
+  {%- endif -%}
+  {%- if page.hero_video is defined and page.hero_video -%}
+    {%- set video = {'@context':'https://schema.org','@type':'VideoObject','name':page.h1 or page.title,'thumbnailUrl':page.hero_poster,'uploadDate':'','contentUrl':page.hero_video} -%}
+    {%- set data = data + [video] -%}
+  {%- endif -%}
+  {{ data }}
+{%- endmacro %}

--- a/templates/_partials/footer.html
+++ b/templates/_partials/footer.html
@@ -1,12 +1,34 @@
 <!-- ============ FOOTER ============ -->
 <footer class="site-footer">
   <div class="container foot-row">
-    <div>© {{ BRAND }}</div>
+    <div>© {{ SEO.brand(company) }}</div>
     <nav class="foot-nav" aria-label="Footer">
       <a href="{{ url_of('contact', _lang) }}">{{ STR.menu_contact }}</a>
       <a href="{{ url_of('about', _lang) }}">{{ STR.menu_about }}</a>
       <a href="{{ url_of('licenses-insurance', _lang) }}">{{ STR.licenses_label }}</a>
     </nav>
+    {% if company is defined and company and company[0] %}
+      {% set c = company[0] %}
+      <address>
+        {% if c.streetAddress %}{{ c.streetAddress }}, {{ c.postalCode }} {{ c.addressLocality }}{% endif %}<br>
+        {% if c.telephone %}<a href="tel:{{ c.telephone }}">{{ c.telephone }}</a><br>{% endif %}
+        {% if c.email %}<a href="mailto:{{ c.email }}">{{ c.email }}</a>{% endif %}
+      </address>
+      {% set json = {
+        '@context':'https://schema.org',
+        '@type':'LocalBusiness',
+        'name': c.name or '',
+        'telephone': c.telephone or '',
+        'email': c.email or '',
+        'address': {
+          '@type':'PostalAddress',
+          'streetAddress': c.streetAddress or '',
+          'addressLocality': c.addressLocality or '',
+          'postalCode': c.postalCode or '',
+          'addressCountry': c.addressCountry or ''
+        }
+      } %}
+      <script type="application/ld+json">{{ json | tojson }}</script>
+    {% endif %}
   </div>
 </footer>
-

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -1,228 +1,78 @@
-<!-- ============ HEADER / MEGA NAV ============ -->
-<header id="header" class="site-header" role="banner">
+<!-- ============ HEADER / NAVIGATION ============ -->
+<header class="site-header" role="banner">
   <div class="container navbar">
-    <a class="brand" href="/{{ _lang }}/" aria-label="Home">
+    <a class="brand" href="/{{ _lang }}/">
       <span class="brand__logo" aria-hidden="true">K</span>
       <span class="brand__name">{{ BRAND }}</span>
     </a>
-
+    {% if NAV_CFG is defined and NAV_CFG.get('items') %}
     <nav class="nav" aria-label="Primary">
       <ul class="nav__list" role="menubar">
-        <li role="none">
-          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="services">
-            {{ STR.menu_services }}
-            <svg class="chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
-          </button>
-        </li>
-        <li role="none">
-          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="industries">
-            {{ STR.menu_biz }}
-            <svg class="chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
-          </button>
-        </li>
-        <li role="none">
-          <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="resources">
-            {{ STR.menu_resources }}
-            <svg class="chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
-          </button>
-        </li>
-        <li role="none"><a class="nav__btn" role="menuitem" href="{{ url_of('about', _lang) }}">{{ STR.menu_about }}</a></li>
-        <li role="none"><a class="nav__btn" role="menuitem" href="/{{ _lang }}/flota/">{{ STR.menu_fleet }}</a></li>
-        <li role="none"><a class="nav__btn" role="menuitem" href="/{{ _lang }}/blog/">{{ STR.menu_blog }}</a></li>
+        {% for item in NAV_CFG.get('items') %}
+          <li role="none">
+            {% if item.children %}
+              <button class="nav__btn" role="menuitem" aria-haspopup="true" aria-expanded="false" data-panel="panel-{{ loop.index0 }}">{{ item.label }}</button>
+            {% else %}
+              <a class="nav__btn" role="menuitem" href="{{ item.href }}">{{ item.label }}</a>
+            {% endif %}
+          </li>
+        {% endfor %}
       </ul>
     </nav>
-
+    {% endif %}
     <div class="actions">
       <a href="#quote" class="cta nojs-hide">{{ STR.hero_cta_primary }}</a>
-
       <div class="lang" data-lang>
-        <button class="icon-btn" aria-haspopup="true" aria-expanded="false" aria-controls="lang-panel" title="Language">
-          <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h16M4 12h16M4 19h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-        </button>
+        <button class="icon-btn" aria-haspopup="true" aria-expanded="false" aria-controls="lang-panel" title="Language">🌐</button>
         <div id="lang-panel" class="lang__panel" role="menu" aria-label="Select language">
           <ul class="lang__list">
-            <li><a href="/pl/" role="menuitem">🇵🇱 Polski</a></li>
-            <li><a href="/en/" role="menuitem">🇬🇧 English</a></li>
-            <li><a href="/de/" role="menuitem">🇩🇪 Deutsch</a></li>
-            <li><a href="/fr/" role="menuitem">🇫🇷 Français</a></li>
-            <li><a href="/it/" role="menuitem">🇮🇹 Italiano</a></li>
-            <li><a href="/ru/" role="menuitem">🇷🇺 Русский</a></li>
-            <li><a href="/ua/" role="menuitem">🇺🇦 Українська</a></li>
+            {% for L in NAV_CFG.langs if NAV_CFG is defined and NAV_CFG.langs %}
+              <li><a href="{{ L.href }}" role="menuitem">{{ L.label }}</a></li>
+            {% endfor %}
           </ul>
         </div>
       </div>
-
-      <button id="themeToggle" class="icon-btn" aria-label="Theme">
-        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path id="themeIcon" d="M12 3a9 9 0 100 18 7 7 0 010-18z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
-      </button>
-
-      <button class="icon-btn hamburger" id="hamburger" aria-expanded="false" aria-controls="drawer" aria-label="Menu">
-        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
-      </button>
+      <button class="icon-btn hamburger" id="hamburger" aria-expanded="false" aria-controls="drawer" aria-label="Menu">☰</button>
     </div>
   </div>
-
-  <!-- ===== Mega panels (desktop) ===== -->
   <div class="panels">
-    <div class="panel" id="panel-services" hidden>
-      <div class="container panel__grid">
-        <div class="panel__col">
-          <h4>Transport</h4>
-          <a class="panel__link" href="/{{ _lang }}/transport-ekspresowy/"><strong>Ekspres bus 3,5 t</strong> <span class="chip">Same day</span></a>
-          <a class="panel__link" href="/{{ _lang }}/tir/"><strong>Transport TIR (FTL/LTL)</strong></a>
-          <a class="panel__link" href="/{{ _lang }}/przeprowadzki-b2b/"><strong>Przeprowadzki B2B</strong></a>
-          <a class="panel__link" href="/{{ _lang }}/adr/"><strong>ADR*</strong> <span class="chip">po potwierdzeniu</span></a>
-        </div>
-        <div class="panel__col">
-          <h4>Spedycja</h4>
-          <a class="panel__link" href="#"><strong>Stałe trasy dla firm</strong></a>
-          <a class="panel__link" href="#"><strong>Planowanie i konsolidacja</strong></a>
-          <a class="panel__link" href="#"><strong>Fulfillment & cross-dock</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Kierunki</h4>
-          <a class="panel__link" href="#"><strong>Polska</strong></a>
-          <a class="panel__link" href="#"><strong>Niemcy</strong></a>
-          <a class="panel__link" href="#"><strong>Francja</strong></a>
-          <a class="panel__link" href="#"><strong>Benelux & Włochy</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Szybkie akcje</h4>
-          <a class="panel__link" href="#quote"><strong>Wyceń transport</strong></a>
-          <a class="panel__link" href="{{ url_of('contact', _lang) }}"><strong>{{ STR.menu_contact }}</strong></a>
-          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
+    {% set panels = menu_panels if menu_panels is defined else [] %}
+    {% for key, items in panels|groupby('panel_key') %}
+      <div class="panel" id="panel-{{ key }}" hidden>
+        <div class="container panel__grid">
+          {% for col, col_items in items|groupby('column') %}
+            <div class="panel__col">
+              {% for it in col_items|sort(attribute='order') %}
+                {% if it.type == 'promo' %}
+                  <div data-promo data-tags="{{ it.tags }}"></div>
+                {% else %}
+                  <a class="panel__link" href="{{ it.href }}">{{ it.label }}</a>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% endfor %}
         </div>
       </div>
-    </div>
-
-    <div class="panel" id="panel-industries" hidden>
-      <div class="container panel__grid">
-        <div class="panel__col">
-          <h4>Branże</h4>
-          <a class="panel__link" href="#"><strong>E-commerce & 3PL</strong></a>
-          <a class="panel__link" href="#"><strong>Automotive</strong></a>
-          <a class="panel__link" href="#"><strong>Retail & FMCG</strong></a>
-          <a class="panel__link" href="#"><strong>High-tech</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Use cases</h4>
-          <a class="panel__link" href="#"><strong>JIT / produkcja</strong></a>
-          <a class="panel__link" href="#"><strong>Zwroty & reverse</strong></a>
-          <a class="panel__link" href="#"><strong>Event logistics</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Dokumenty</h4>
-          <a class="panel__link" href="#"><strong>Wzór zlecenia</strong></a>
-          <a class="panel__link" href="#"><strong>Warunki współpracy</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Kontakt B2B</h4>
-          <a class="panel__link" href="#quote"><strong>Stała umowa / cennik</strong></a>
-          <a class="panel__link" href="{{ url_of('contact', _lang) }}"><strong>Zostaw brief</strong></a>
-        </div>
-      </div>
-    </div>
-
-    <div class="panel" id="panel-resources" hidden>
-      <div class="container panel__grid">
-        <div class="panel__col">
-          <h4>Materiały</h4>
-          <a class="panel__link" href="/{{ _lang }}/blog/"><strong>Blog</strong></a>
-          <a class="panel__link" href="/{{ _lang }}/case-studies/"><strong>Case studies</strong></a>
-          <a class="panel__link" href="#"><strong>Poradniki</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Narzędzia</h4>
-          <a class="panel__link" href="#"><strong>Kalkulator objętości</strong></a>
-          <a class="panel__link" href="#quote"><strong>Wycena online</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Wsparcie</h4>
-          <a class="panel__link" href="#faq"><strong>FAQ</strong></a>
-          <a class="panel__link" href="{{ url_of('contact', _lang) }}"><strong>{{ STR.menu_contact }}</strong></a>
-        </div>
-        <div class="panel__col">
-          <h4>Informacje</h4>
-          <a class="panel__link" href="{{ url_of('about', _lang) }}"><strong>{{ STR.menu_about }}</strong></a>
-          <a class="panel__link" href="/{{ _lang }}/flota/"><strong>{{ STR.menu_fleet }}</strong></a>
-        </div>
-      </div>
-    </div>
+    {% endfor %}
   </div>
 </header>
 
 <!-- ============ MOBILE DRAWER ============ -->
 <div class="drawer" id="drawer" hidden aria-hidden="true">
-  <div class="drawer__head">
-    <div class="brand"><span class="brand__logo">K</span><span class="brand__name">{{ BRAND }}</span></div>
-    <button class="icon-btn" id="drawerClose" aria-label="Zamknij">
-      <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-    </button>
-  </div>
-  <div class="drawer__body">
-    <nav aria-label="Mobile">
-      <div class="acc">
-        <button class="acc__btn" aria-expanded="false">{{ STR.menu_services }}
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
-        </button>
-        <div class="acc__panel">
-          <ul class="sublist">
-            <li><a href="/{{ _lang }}/transport-ekspresowy/">Ekspres bus 3,5 t</a></li>
-            <li><a href="/{{ _lang }}/tir/">Transport TIR (FTL/LTL)</a></li>
-            <li><a href="/{{ _lang }}/przeprowadzki-b2b/">Przeprowadzki B2B</a></li>
-            <li><a href="/{{ _lang }}/adr/">ADR*</a></li>
-          </ul>
-        </div>
-      </div>
-      <div class="acc">
-        <button class="acc__btn" aria-expanded="false">{{ STR.menu_biz }}
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
-        </button>
-        <div class="acc__panel">
-          <ul class="sublist">
-            <li><a href="#">Branże</a></li>
-            <li><a href="#">JIT / produkcja</a></li>
-            <li><a href="#">Warunki współpracy</a></li>
-          </ul>
-        </div>
-      </div>
-      <div class="acc">
-        <button class="acc__btn" aria-expanded="false">{{ STR.menu_resources }}
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
-        </button>
-        <div class="acc__panel">
-          <ul class="sublist">
-            <li><a href="/{{ _lang }}/blog/">Blog</a></li>
-            <li><a href="#">Case studies</a></li>
-            <li><a href="#faq">FAQ</a></li>
-          </ul>
-        </div>
-      </div>
-
-      <a class="sublist" href="{{ url_of('about', _lang) }}" style="display:block;padding:14px 0">{{ STR.menu_about }}</a>
-      <a class="sublist" href="/{{ _lang }}/flota/" style="display:block;padding:14px 0">{{ STR.menu_fleet }}</a>
-      <a class="sublist" href="/{{ _lang }}/blog/"  style="display:block;padding:14px 0">{{ STR.menu_blog }}</a>
-
-      <div style="padding:16px 0;display:flex;gap:10px">
-        <a class="cta" href="#quote" style="flex:1;justify-content:center">{{ STR.hero_cta_primary }}</a>
-        <a class="icon-btn" href="tel:{{ PHONE }}" aria-label="Call">
-          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.86 19.86 0 0 1-3.07-8.63A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.12.89.31 1.76.57 2.6a2 2 0 0 1-.45 2.11L8 9a16 16 0 0 0 6 6l.57-.22a2 2 0 0 1 2.11.45c.84.26 1.71.45 2.6.57A2 2 0 0 1 22 16.92z" stroke="currentColor" stroke-width="2" fill="none"/></svg>
-        </a>
-      </div>
-    </nav>
-  </div>
+  <nav aria-label="Mobile">
+    <ul>
+      {% if NAV_CFG is defined and NAV_CFG.get('items') %}
+        {% for it in NAV_CFG.get('items') %}
+          <li><a href="{{ it.href }}">{{ it.label }}</a></li>
+        {% endfor %}
+      {% endif %}
+    </ul>
+  </nav>
 </div>
 
-<!-- ============ MOBILE BOTTOM DOCK (always visible) ============ -->
-<nav class="mobile-dock" aria-label="Quick actions">
-  <a id="dock-home" class="dock-btn" href="/{{ _lang }}/" aria-label="Home">
-    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5l9-7 9 7V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1z" fill="currentColor"/></svg>
-    <span>{{ STR.dock_home }}</span>
-  </a>
-  <a id="dock-quote" class="dock-cta" href="#quote" aria-label="Quote">{{ STR.hero_cta_primary }}</a>
-  <button id="dock-menu" class="dock-btn" aria-label="Menu" aria-controls="drawer" aria-expanded="false">
-    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
-    <span>{{ STR.dock_menu }}</span>
-  </button>
+<!-- ============ DOCK (BOTTOM NAV) ============ -->
+<nav class="dock" aria-label="Dock">
+  <a href="/{{ _lang }}/">{{ STR.dock_home }}</a>
+  <a href="#quote">Wycena</a>
+  <a href="#drawer" id="dockMenu">{{ STR.dock_menu }}</a>
 </nav>
-

--- a/templates/case.html
+++ b/templates/case.html
@@ -43,20 +43,22 @@
   {% include '_partials/header.html' %}
   <main>
     {{ page_html|safe }}
-    {% if page.min_outlinks is defined and page.max_outlinks is defined %}
-      {% set links = SEO.outlinks(page, PAGES, page.min_outlinks, page.max_outlinks, page.suggest_links, page.anchor_text_suggestions) %}
-      {% if links %}
-      <nav class="outlinks" aria-label="Related">
-        <ul>
-          {% for l in links %}
-            <li><a href="{{ l.href }}">{{ l.anchor }}</a></li>
-          {% endfor %}
-        </ul>
-      </nav>
-      {% endif %}
-    {% endif %}
   </main>
   <script type="application/ld+json">{{ SEO.structured(page, company, BLOCKS)|tojson }}</script>
+  <script type="application/ld+json">{{ {
+    '@context':'https://schema.org',
+    '@type':'Article',
+    'headline': page.seo_title if page.seo_title is defined and page.seo_title else page.title,
+    'image': page.hero_image if page.hero_image is defined else '',
+    'author': {'@type':'Person','name': page.author} if page.author is defined else {},
+    'datePublished': page.published if page.published is defined else '' }|tojson }}</script>
+  {% if page.kpi is defined %}
+  <script type="application/ld+json">{{ {
+    '@context':'https://schema.org',
+    '@type':'Review',
+    'itemReviewed': {'@type':'Thing','name': page.h1 or page.title},
+    'reviewBody': page.kpi }|tojson }}</script>
+  {% endif %}
   {% include '_partials/footer.html' %}
 </body>
 </html>

--- a/templates/post.html
+++ b/templates/post.html
@@ -43,20 +43,15 @@
   {% include '_partials/header.html' %}
   <main>
     {{ page_html|safe }}
-    {% if page.min_outlinks is defined and page.max_outlinks is defined %}
-      {% set links = SEO.outlinks(page, PAGES, page.min_outlinks, page.max_outlinks, page.suggest_links, page.anchor_text_suggestions) %}
-      {% if links %}
-      <nav class="outlinks" aria-label="Related">
-        <ul>
-          {% for l in links %}
-            <li><a href="{{ l.href }}">{{ l.anchor }}</a></li>
-          {% endfor %}
-        </ul>
-      </nav>
-      {% endif %}
-    {% endif %}
   </main>
   <script type="application/ld+json">{{ SEO.structured(page, company, BLOCKS)|tojson }}</script>
+  <script type="application/ld+json">{{ {
+    '@context':'https://schema.org',
+    '@type':'BlogPosting',
+    'headline': page.seo_title if page.seo_title is defined and page.seo_title else page.title,
+    'image': page.hero_image if page.hero_image is defined else '',
+    'datePublished': page.published if page.published is defined else '',
+    'author': {'@type':'Person','name': page.author} if page.author is defined else {} }|tojson }}</script>
   {% include '_partials/footer.html' %}
 </body>
 </html>

--- a/templates/sitemap-lang.xml
+++ b/templates/sitemap-lang.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+{% for p in pages if p.publish and p.lang == lang %}
+  <url>
+    <loc>{{ site_url }}{{ '/' ~ p.lang ~ '/' ~ (p.slug and p.slug ~ '/' or '') }}</loc>
+    {% set alt = hreflang[p.slugKey or p.slug] if hreflang is defined else {} %}
+    {% for code, href in alt.items() %}
+      <xhtml:link rel="alternate" hreflang="{{ 'uk' if code=='ua' else code }}" href="{{ href }}" />
+    {% endfor %}
+  </url>
+{% endfor %}
+</urlset>

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% set langs = pages|selectattr('publish','equalto',True)|map(attribute='lang')|unique if pages is defined else [] %}
+  {% for l in langs %}
+  <sitemap>
+    <loc>{{ site_url }}/sitemap-{{ l }}.xml</loc>
+  </sitemap>
+  {% endfor %}
+</sitemapindex>


### PR DESCRIPTION
## Summary
- add Jinja SEO macro library with canonical, hreflang, breadcrumbs and structured data helpers
- rebuild header and footer to use navigation data and emit LocalBusiness JSON-LD
- simplify page/post/case templates and add sitemap and robots templates

## Testing
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a24e404d848333a3bc7189ace2cda8