### PR TITLE
Handle home slug root path in link_for macro

### DIFF
--- a/templates/_partials/footer.html
+++ b/templates/_partials/footer.html
@@ -4,7 +4,15 @@
 {% set HREF = hreflang if hreflang is defined else {} %}
 {% macro link_for(slugkey, lang) -%}
   {%- set m = HREF.get(slugkey, {}) -%}
-  {%- if m and m.get(lang) -%}{{ m[lang] }}{%- else -%}/{{ lang }}/{{ slugkey }}/ {%- endif -%}
+  {%- if m and m.get(lang) -%}
+    {{ m[lang] }}
+  {%- else -%}
+    {%- if slugkey == 'home' -%}
+      /{{ lang }}/
+    {%- else -%}
+      /{{ lang }}/{{ slugkey }}/
+    {%- endif -%}
+  {%- endif -%}
 {%- endmacro %}
 {% set STR = (strings if strings is defined and strings else {}) %}
 {% set LBL_LICENSES = STR.get('licenses_label','Licencje & ubezpieczenia') %}

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -24,7 +24,11 @@
   {%- if m and m.get(lang) -%}
     {{ m[lang] }}
   {%- else -%}
-    /{{ lang }}/{{ slugkey }}/
+    {%- if slugkey == 'home' -%}
+      /{{ lang }}/
+    {%- else -%}
+      /{{ lang }}/{{ slugkey }}/
+    {%- endif -%}
   {%- endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
## Summary
- Adjust link_for macro so `home` slug generates language root path

## Testing
- `pip install -r requirements.txt`
- `python tools/build.py` *(fails: 'SEO' is undefined)*
- `bash tools/test_footer.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a2650d07c08333835bff4141ce6d23