### PR TITLE
Handle missing CMS secrets in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,8 @@ jobs:
       GA_ID: "G-5FYE42J3BE"
       GSC_VERIFICATION: "Q3XgXOegwnvV6sBj31MbGlldhfD2uzmHBnR6kvLFj7Y"
       CNAME: kras-trans.com
+      APPS_URL: ${{ secrets.APPS_URL }}
+      APPS_KEY: ${{ secrets.APPS_KEY }}
 
     steps:
       # ————————————————————————————————
@@ -58,9 +60,7 @@ jobs:
       # 2) Wstępna walidacja sekretów (czy nie puste)
       # ————————————————————————————————
       - name: Preflight secrets check
-        env:
-          APPS_URL: ${{ secrets.APPS_URL }}
-          APPS_KEY: ${{ secrets.APPS_KEY }}
+        if: env.APPS_URL != '' && env.APPS_KEY != ''
         run: |
           set -euo pipefail
           test -n "${APPS_URL:-}" || { echo "::error::Missing secret APPS_URL"; exit 1; }
@@ -71,9 +71,7 @@ jobs:
       # 3) Pobranie CMS z Apps Script (odporne)
       # ————————————————————————————————
       - name: Fetch CMS JSON from Apps Script (robust)
-        env:
-          APPS_URL: ${{ secrets.APPS_URL }}
-          APPS_KEY: ${{ secrets.APPS_KEY }}
+        if: env.APPS_URL != '' && env.APPS_KEY != ''
         run: |
           set -euo pipefail
           mkdir -p data


### PR DESCRIPTION
## Summary
- Skip CMS download when `APPS_URL`/`APPS_KEY` secrets are absent
- Define CMS secrets as workflow environment variables

## Testing
- `pytest`
- `python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2ea2dd3a483339afef0203b93d4e8