### PR TITLE
Fix footer SEO brand variable

### DIFF
--- a/templates/_partials/footer.html
+++ b/templates/_partials/footer.html
@@ -21,7 +21,7 @@
 <!-- ============ FOOTER ============ -->
 <footer class="site-footer">
   <div class="container foot-row">
-    <div>© {{ SEO.brand(company) }}</div>
+    <div>© {{ BRAND }}</div>
     <nav class="foot-nav" aria-label="Footer">
 <a href="{{ link_for('contact', _lang) }}">{{ LBL_CONTACT }}</a>
 <a href="{{ link_for('about', _lang) }}">{{ LBL_ABOUT }}</a>


### PR DESCRIPTION
## Summary
- avoid `SEO` undefined error in footer by using precomputed `BRAND`

## Testing
- `python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2eccf9d108333ae4d9f75f78ec03a