### PR TITLE
Clean up header assets and navigation fallback

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -17,7 +17,7 @@
   const HEADER = document.getElementById('site-header');
   const DEFAULT_LANG = (HEADER?.dataset.defaultLang) || (SCRIPT?.dataset.defaultLang) || 'pl';
   const CMS_ENDPOINT = (SCRIPT?.dataset.api) || (HEADER?.dataset.api) || '';
-  const LOGO_SRC = HEADER?.dataset.logoSrc || '/assets/media/logo.png';
+  const LOGO_SRC = HEADER?.dataset.logoSrc || '/assets/media/logo-firma-transportowa-kras-trans.png';
 
   // --------- UTIL
   const qs  = (s, root=document) => root.querySelector(s);

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -133,3 +133,8 @@ en:
   logo:
     src: "/assets/media/logo-firma-transportowa-kras-trans.png"
     alt: "Kras‑Trans — transport & forwarding"
+
+  social:
+    ig: "https://www.instagram.com/kras_trans.express.eu?igsh=bHZkODhlazFicGt2&utm_source=qr"
+    li: "https://www.linkedin.com/company/kras-trans"
+    fb: "https://www.facebook.com/share/sS2jgJPwdgvrF4az/?mibextid=LQQJ4d"

--- a/index.html
+++ b/index.html
@@ -18,13 +18,6 @@
   <!-- Preload critical assets (fonts, CSS) -->
   <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="/assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/assets/css/app.css" as="style" />
-  <!-- Asynchronous CSS loading (prevents render-blocking) -->
-  <link rel="stylesheet" href="/assets/css/app.css" media="print" onload="this.media='all'; this.onload=null;" />
-  <noscript>
-    <!-- Fallback for no-JS: load CSS normally -->
-    <link rel="stylesheet" href="/assets/css/app.css" />
-  </noscript>
   <style>
     /* Visually hidden utility (for accessibility) */
     .visually-hidden { position:absolute !important; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); clip-path:inset(50%); white-space:nowrap; border:0; }
@@ -241,6 +234,5 @@
     /* Globalna konfiguracja menu z CMS (wstawiana podczas build) */
     window.KRAS_NAV = {{ nav_cfg | tojson }};
   </script>
-  <script src="/assets/js/app.js" defer></script>
 </body>
 </html>

--- a/templates/company/licenses-insurance.html
+++ b/templates/company/licenses-insurance.html
@@ -71,7 +71,6 @@
 
   <link rel="preload" href="/assets/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/InterVariable-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="stylesheet" href="/assets/css/app.css">
 
   {% set faqs = (blocks|selectattr('block','equalto','faq')|selectattr('page','equalto',_slug)|selectattr('lang','equalto',_lang)|list) if blocks is defined else [] %}
   <script type="application/ld+json">
@@ -223,7 +222,6 @@
   </main>
 
   {% include "_partials/footer.html" %}
-  <script src="/assets/js/app.js" defer></script>
 
   {# prosty formatter Markdown -> <br>/<p>/<strong> dla [data-md] i .lead #}
   <script>


### PR DESCRIPTION
## Summary
- remove obsolete app.css/app.js links so only site.css, site.js and cms.js load
- point header fallback logo to current image
- extend nav YAML fallback with English social links

## Testing
- `python tools/build.py` *(fails to fetch GAS due to proxy, falls back to local data)*

------
https://chatgpt.com/codex/tasks/task_e_68a704b442688333943d34638d0f07cb