### PR TITLE
chore: tighten Pages workflow resilience

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,8 +57,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail; set -x
-          sudo apt-get update -y
-          sudo apt-get install -y jq zip tree
+          timeout 60s sudo apt-get update -y
+          timeout 60s sudo apt-get install -y jq zip tree
 
       # ---------- Python ----------
       - name: Setup Python


### PR DESCRIPTION
## Summary
- add 60s timeouts to apt-get update/install in tool-setup step
- confirm build steps run under bash with fail-fast and tracing

## Testing
- `yamllint .github/workflows/pages.yml` *(fails: too many spaces, long lines, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a74c71c7348333a4df2443bc0bb14f