### PR TITLE
feat: improve mega menu interactions

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -71,6 +71,24 @@
     return `/${LANG}/${slug ? (slug + '/') : ''}`;
   }
 
+  let openTO, closeTO, activeLi;
+  function scheduleOpen(key, li) {
+    clearTimeout(openTO); clearTimeout(closeTO);
+    openTO = setTimeout(() => openPanel(key, li), 200);
+  }
+  function scheduleClose(key, li) {
+    clearTimeout(openTO); clearTimeout(closeTO);
+    closeTO = setTimeout(() => closePanel(key, li), 400);
+  }
+
+  if (mega) {
+    mega.addEventListener('mouseenter', () => clearTimeout(closeTO));
+    mega.addEventListener('mouseleave', () => {
+      const key = mega.dataset.active;
+      if (key) scheduleClose(key, activeLi);
+    });
+  }
+
   /* ========= Render ========= */
   function renderFromBundle(bundle) {
     if (!bundle) return;
@@ -83,7 +101,20 @@
 
     // MEGA‑PANELE
     if (mega && bundle.mega_html) {
-      mega.innerHTML = passHTML(bundle.mega_html);
+      const tmp = document.createElement('div');
+      tmp.innerHTML = passHTML(bundle.mega_html);
+      const sections = tmp.querySelectorAll('section');
+      const grid = document.createElement('div');
+      grid.style.display = 'grid';
+      grid.style.gridTemplateColumns = 'repeat(3, 1fr)';
+      sections.forEach(sec => grid.appendChild(sec));
+      mega.innerHTML = '';
+      mega.appendChild(grid);
+      mega.style.display = 'none';
+      mega.style.opacity = '0';
+      mega.style.transform = 'translateY(-8px)';
+      mega.style.transition = 'opacity 300ms cubic-bezier(.2,.7,.2,1), transform 300ms cubic-bezier(.2,.7,.2,1)';
+      mega.style.pointerEvents = 'none';
     }
 
     // JĘZYKI
@@ -152,8 +183,8 @@
       if (hasPanel) {
         li.classList.add('has-panel');
         // Hover (desktop)
-        li.addEventListener('mouseenter', () => openPanel(panel, li));
-        li.addEventListener('mouseleave', () => closePanel(panel, li));
+        li.addEventListener('mouseenter', () => scheduleOpen(panel, li));
+        li.addEventListener('mouseleave', () => scheduleClose(panel, li));
         // Tap/click (mobile + fallback)
         li.addEventListener('click', (e) => {
           const targetA = e.target.closest('a');
@@ -171,19 +202,37 @@
       const active = list.querySelector(`a[href="${cur}"]`);
       if (active) active.setAttribute('aria-current', 'page');
     } catch(_) {}
+
   }
 
   function openPanel(key, li) {
     if (!mega || !key) return;
+    clearTimeout(openTO); clearTimeout(closeTO);
+    if (mega.dataset.active !== key) {
+      activeLi?.querySelector('a[aria-expanded]')?.setAttribute('aria-expanded','false');
+    }
+    activeLi = li || activeLi;
     mega.dataset.active = key;
+    mega.style.display = 'block';
+    requestAnimationFrame(() => {
+      mega.style.pointerEvents = 'auto';
+      mega.style.opacity = '1';
+      mega.style.transform = 'translateY(0)';
+    });
     root.classList.add('mega-open');
     li?.querySelector('a[aria-expanded]')?.setAttribute('aria-expanded','true');
   }
   function closePanel(key, li) {
     if (!mega || !key) return;
+    clearTimeout(openTO); clearTimeout(closeTO);
     if (mega.dataset.active === key) { delete mega.dataset.active; }
+    mega.style.opacity = '0';
+    mega.style.transform = 'translateY(-8px)';
+    mega.style.pointerEvents = 'none';
+    setTimeout(() => { mega.style.display = 'none'; }, 300);
     root.classList.remove('mega-open');
-    li?.querySelector('a[aria-expanded]')?.setAttribute('aria-expanded','false');
+    (li || activeLi)?.querySelector('a[aria-expanded]')?.setAttribute('aria-expanded','false');
+    activeLi = null;
   }
   function togglePanel(key, li) {
     if (!mega || !key) return;


### PR DESCRIPTION
## Summary
- Parse CMS `mega_html` into section grid and attach 3-column layout
- Add fade+slide animation and hover-intent delays for mega menu
- Keep panel open while pointer is inside mega panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af81228c8333b9ad7f7cc4a5629d