### PR TITLE
Allow nav menu to wrap instead of scroll

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -113,8 +113,7 @@ img,svg,video{max-width:100%; height:auto; display:block}
 .sq-nav .nav__list{
   list-style:none; margin:0; padding:0;
   display:flex; gap:6px; align-items:center;
-  flex-wrap:nowrap;           /* <— jeden pasek */
-  overflow-x:auto;            /* poziomy scroll */
+  flex-wrap:wrap;             /* wrap to multiple rows */
   -webkit-overflow-scrolling:touch;
   scroll-behavior:smooth;
 }


### PR DESCRIPTION
## Summary
- Wrap navigation list items and drop horizontal overflow.

## Testing
- `pip install -r requirements.txt`
- `APPS_URL="https://example.com" APPS_KEY="dummy" python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a86a9e42108333bcfef26a1994e273