### PR TITLE
feat: open mega menu on hover

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -327,7 +327,7 @@ img,svg,video{max-width:100%; height:auto; display:block}
 .mega{position:absolute;left:50%;transform:translateX(-50%);top:120%;width:100vw;max-width:1200px;background:#fff;border:1px solid #e5e7eb;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.08);padding:20px;display:none;z-index:1000}
 .mega-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:20px}
 .mega-col ul{list-style:none;margin:0;padding:0}
-.has-mega>.mega-toggle[aria-expanded="true"]+.mega{display:block}
+.has-mega>.mega-toggle[aria-expanded="true"]+.mega{display:block;pointer-events:auto}
 @media(max-width:960px){
   .mega{position:static;transform:none;width:auto;display:block}
   .mega-grid{grid-template-columns:1fr}

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -43,14 +43,12 @@
     const btns = $$('.mega-toggle');
     function closeAll(except){ btns.forEach(b=>{ if(b!==except) b.setAttribute('aria-expanded','false'); }); }
     btns.forEach(btn=>{
-      const panel = document.getElementById(btn.getAttribute('aria-controls'));
       const set = v=>btn.setAttribute('aria-expanded', v?'true':'false');
-      btn.addEventListener('click', e=>{
+      btn.addEventListener('mouseenter', e=>{
         e.stopPropagation();
-        const open = btn.getAttribute('aria-expanded') !== 'true';
-        closeAll(btn); set(open);
+        closeAll(btn); set(true);
       });
-      if (panel) panel.addEventListener('mouseleave', ()=>set(false));
+      btn.addEventListener('mouseleave', ()=>set(false));
     });
     document.addEventListener('click', ()=>closeAll(null));
     document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(null); });

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -83,6 +83,7 @@
     .mega{position:absolute;left:0;right:0;top:100%;pointer-events:none;transform:translateY(-8px);opacity:0;
       transition:transform .24s var(--ease),opacity .24s var(--ease)}
     .mega[data-state="open"]{pointer-events:auto;transform:translateY(0);opacity:1}
+    .has-mega>.mega-toggle[aria-expanded="true"]+.mega{pointer-events:auto;transform:translateY(0);opacity:1}
     .mega .mega__wrap{padding:12px 0 18px}
     .mega .mega__grid-wrap{display:grid;grid-template-columns:1fr minmax(260px,320px);gap:16px;align-items:start}
     .mega .mega__panels{max-height:var(--mega-h);overflow:hidden;transition:max-height .28s var(--ease)}


### PR DESCRIPTION
## Summary
- open mega menu on `mouseenter` and close on `mouseleave`
- show mega menu when toggle has `aria-expanded="true"`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ce8f1a48333aa6f9f25901ff5fe