### PR TITLE
Warn on duplicate CMS labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ For local experiments a simplified variant is available at
 `tools/build_local.py`. It uses the same `APPS_URL` and `APPS_KEY` variables and
 also outputs to `dist/`.
 
+## CMS data
+
+Menu labels must be unique within each language. During the build process,
+duplicate labels trigger a warning and the later entries are ignored.
+

--- a/tools/menu_builder.py
+++ b/tools/menu_builder.py
@@ -5,6 +5,7 @@ Menu Builder for Kras-Trans.
 - Reads data/cms/cms.json OR cms.csv OR cms.xlsx (first sheet).
 - Expected columns: lang, label, href, parent, order, col, enabled
 - Produces per-language bundles and pre-rendered HTML for instant SSR.
+- Labels must be unique within each language; duplicates emit a warning and are ignored.
 """
 from __future__ import annotations
 import csv, json, hashlib, re, unicodedata, datetime
@@ -116,10 +117,11 @@ def load_cms(cms_dir: Path) -> List[Dict[str, Any]]:
     else:
         return []
 
-    # Normalizacja jak dotąd
-    norm = []
+    # Normalizacja jak dotąd + kontrola duplikatów etykiet per język
+    norm: List[Dict[str, Any]] = []
+    labels_by_lang: Dict[str, set] = {}
     for r in raw:
-        lang = str(r.get("lang","pl")).strip().lower()
+        lang = str(r.get("lang", "pl")).strip().lower()
         label = _sanitize_label(r.get("label"))
         parent = _sanitize_label(r.get("parent"))
         href = _sanitize_href(r.get("href"), lang, label)
@@ -128,10 +130,23 @@ def load_cms(cms_dir: Path) -> List[Dict[str, Any]]:
         enabled = _to_bool(r.get("enabled"))
         if not label:
             continue
+
+        seen = labels_by_lang.setdefault(lang, set())
+        if label in seen:
+            print(f"[menu_builder] WARNING: duplicate label '{label}' for lang '{lang}' — skipping")
+            continue
+        seen.add(label)
+
         norm.append({
-            "lang": lang, "label": label, "href": href,
-            "parent": parent, "order": order, "col": col, "enabled": enabled
+            "lang": lang,
+            "label": label,
+            "href": href,
+            "parent": parent,
+            "order": order,
+            "col": col,
+            "enabled": enabled,
         })
+
     norm = [r for r in norm if r["enabled"]]
     return norm
 


### PR DESCRIPTION
## Summary
- track per-language labels while normalizing CMS data
- warn and skip duplicate labels for a language
- document that CMS labels must be unique per language

## Testing
- `python -m py_compile tools/menu_builder.py`
- `python - <<'PY'
from pathlib import Path
import json, tempfile
from tools.menu_builder import load_cms

data = [
    {"lang":"en","label":"Home","href":"/home","enabled":True},
    {"lang":"en","label":"Home","href":"/duplicate","enabled":True},
    {"lang":"pl","label":"Start","href":"/","enabled":True},
    {"lang":"pl","label":"Start","href":"/dup","enabled":True}
]
with tempfile.TemporaryDirectory() as tmpdir:
    p = Path(tmpdir)/"cms.json"
    p.write_text(json.dumps(data), encoding="utf-8")
    rows = load_cms(Path(tmpdir))
    print("rows:", rows)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a870dd81a083339e76075086bf48cf