### PR TITLE
Ensure internal hrefs end with trailing slash

### DIFF
--- a/tests/test_sanitize_href.py
+++ b/tests/test_sanitize_href.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is on the Python path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tools.menu_builder import _sanitize_href
+
+
+def test_internal_without_trailing_slash():
+    assert _sanitize_href('/foo', 'pl', 'Foo') == '/foo/'
+
+
+def test_internal_with_trailing_slash():
+    assert _sanitize_href('/foo/', 'pl', 'Foo') == '/foo/'
+
+
+def test_internal_with_query_no_trailing_slash():
+    assert _sanitize_href('/foo?x=1', 'pl', 'Foo') == '/foo/?x=1'
+
+
+def test_internal_with_anchor_no_trailing_slash():
+    assert _sanitize_href('/foo#bar', 'pl', 'Foo') == '/foo/#bar'

--- a/tools/menu_builder.py
+++ b/tools/menu_builder.py
@@ -39,7 +39,21 @@ def _sanitize_href(href: Any, lang: str, label: str) -> str:
         return f"/{lang}/{_slugify(label)}/"
     # allowlist protocols
     ok = h.startswith(SAFE_PROTOCOLS)
-    return h if ok else f"/{lang}/{_slugify(label)}/"
+    if not ok:
+        return f"/{lang}/{_slugify(label)}/"
+
+    if h.startswith("/"):
+        # Ensure internal URLs end with a slash. Preserve anchors and queries
+        idx = len(h)
+        for sep in ("#", "?"):
+            pos = h.find(sep)
+            if pos != -1 and pos < idx:
+                idx = pos
+        base, suffix = h[:idx], h[idx:]
+        if not base.endswith("/"):
+            base += "/"
+        h = base + suffix
+    return h
 
 def _load_json(p: Path) -> List[Dict[str, Any]]:
     return json.loads(p.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- sanitize internal URLs to always include a trailing slash, inserting it before anchors or queries
- add unit tests covering URLs with and without trailing slashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a870dc910883338443ba8532d3c25d