### PR TITLE
Allow up to four nav columns

### DIFF
--- a/tools/generate_nav_from_xlsx.py
+++ b/tools/generate_nav_from_xlsx.py
@@ -93,7 +93,7 @@ def read_nav(ws):
         if 'col' in idx:
             try:
                 c = int(row[idx['col']])
-                if 1 <= c <= 3:
+                if 1 <= c <= 4:
                     col = c
             except Exception:
                 pass
@@ -161,17 +161,17 @@ def build_bundle(lang, rows, routes, props):
         kids  = children.get(label, []) + children.get(slug, [])
         if not kids:
             continue
-        cols = {1: [], 2: [], 3: []}
+        cols = {i: [] for i in range(1, 5)}
         for ch in kids:
             try:
                 c = int(ch.get('col') or 1)
             except Exception:
                 c = 1
-            if c not in (1,2,3):
+            if c not in cols:
                 c = 1
             cols[c].append(ch)
         col_divs = []
-        for i in (1,2,3):
+        for i in range(1, 5):
             links = ''.join(f'<div><a href="{r["href"]}">{r["label"]}</a></div>' for r in cols[i])
             col_divs.append(f'<div class="col">{links}</div>')
         sections.append(


### PR DESCRIPTION
## Summary
- Expand navigation column support to four columns
- Dynamically render up to four columns in mega menu

## Testing
- `python -m py_compile tools/generate_nav_from_xlsx.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a870daf1cc8333b2382cd2e7c47415