### PR TITLE
fix menu bundle path for cms script

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -1,11 +1,11 @@
 /* Mega-menu SWR-only:
    - NIE renderuje na starcie (używamy SSR z HTML-a)
    - TYLKO sprawdza wersję bundla i w razie zmiany podmienia menu
-   - pobiera z /assets/data/menu/bundle_{lang}.json (fix 404) */
+   - pobiera z /assets/nav/bundle_{lang}.json (fix 404) */
 (function(){
   const UL_ID = 'primary-nav-list';
   const META_NAME = 'menu-bundle-version';
-  const PREFIX = '/assets/data/menu';
+  const PREFIX = '/assets/nav';
 
   const $ = s => document.querySelector(s);
   const $$ = s => Array.from(document.querySelectorAll(s));


### PR DESCRIPTION
## Summary
- point CMS mega-menu script to `/assets/nav` so it can load language bundles

## Testing
- `python tools/build.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8748ef7308333b4a1bdf3699b3293