### PR TITLE
feat: allow overriding CMS XLSX path

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -337,7 +337,10 @@ def _cms_local_read() -> Dict[str, Any]:
             print(f"[CMS] Błąd CSV: {e}", file=sys.stderr)
 
     # XLSX
-    p_xlsx = base / "cms.xlsx"
+    env_path = os.environ.get("LOCAL_XLSX")
+    p_xlsx = pathlib.Path(env_path) if env_path else (base / "cms.xlsx")
+    if not p_xlsx.exists():
+        p_xlsx = base / "cms.xlsx"
     if p_xlsx.exists():
         try:
             import openpyxl
@@ -349,6 +352,7 @@ def _cms_local_read() -> Dict[str, Any]:
             for row in ws.iter_rows(min_row=2, values_only=True):
                 d = {h: (row[idx[h]] if h in idx else "") for h in headers}
                 rows.append({(k or "").strip(): (str(v or "").strip()) for k, v in d.items()})
+            print(f"[CMS] Lokalnie: {p_xlsx}")
             return {"ok": True, "rows": rows}
         except Exception as e:
             print(f"[CMS] Błąd XLSX: {e}", file=sys.stderr)
@@ -814,7 +818,13 @@ def neighbors_for(
 def build_all():
     # === MENU (lokalnie: SSR + JSON dla SWR) ===
     if _MB:
-        bundles, menu_html_by_lang = _MB.build_all(_MBPath("data/cms"), LOCALES)
+        env_path = os.environ.get("LOCAL_XLSX")
+        cms_dir = _MBPath("data/cms")
+        if env_path:
+            p = _MBPath(env_path)
+            if p.exists():
+                cms_dir = p.parent
+        bundles, menu_html_by_lang = _MB.build_all(cms_dir, LOCALES)
         out = ((_MBPath('dist') if 'OUT' not in globals() else OUT) / "assets" / "data" / "menu")
         out.mkdir(parents=True, exist_ok=True)
         for L, B in bundles.items():


### PR DESCRIPTION
## Summary
- support `LOCAL_XLSX` env var to load CMS spreadsheet from a custom location
- forward selected directory to `menu_builder` for menu generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87b2591748333b7cbde128ff06d6c