### PR TITLE
Remove CMS endpoint meta and Apps Script preconnect

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,9 +10,6 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  <!-- CMS endpoint (dla headera, który ciągnie NAV z GAS) -->
-  <meta name="cms-endpoint" content="{{ cms_endpoint }}" />
-
   <title>{{ page.seo_title or page.title }}</title>
   <meta name="description" content="{{ page.meta_desc }}" />
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
@@ -57,9 +54,6 @@
   {% if assets.manifest %}<link rel="manifest" href="{{ assets.manifest }}" />{% endif %}
 
   {# --- Preconnecty TYLKO jeśli potrzebne --- #}
-{% if 'script.google.com' in (cms_endpoint or '') %}
-    <link rel="preconnect" href="https://script.google.com" crossorigin />
-  {% endif %}
   {% if ga_id %}
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
   {% endif %}

--- a/tools/build.py
+++ b/tools/build.py
@@ -746,11 +746,6 @@ def ensure_head_injections(soup:BeautifulSoup, page:Dict[str,Any], hreflang_map:
     if (GSC or "").strip() and not head.find("meta", attrs={"name":"google-site-verification"}):
         add_meta(name="google-site-verification", content=GSC)
 
-    # cms-endpoint
-    cms_endpoint = (f"{APPS_URL}?key={APPS_KEY}" if APPS_URL and APPS_KEY else "")
-    if cms_endpoint and not head.find("meta", attrs={"name":"cms-endpoint"}):
-        add_meta(name="cms-endpoint", content=cms_endpoint)
-
     # GA (gtag) – wstrzykuj tylko, jeśli w całym dokumencie nie ma już configu
     if (GA_ID or "").strip():
         has_gtm_any = bool(soup.find("script", src=re.compile(r"googletagmanager\.com/gtag/js")))


### PR DESCRIPTION
## Summary
- remove cms-endpoint meta tag and Apps Script preconnect from base template
- drop build-time cms-endpoint meta injection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87b27adc48333a44ca43e2e9c2036