### PR TITLE
Remove Apps Script configuration and cms-endpoint meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,7 @@ Static site for Kras-Trans.
 ## Build scripts
 
 The officially supported build script lives in `tools/build.py`. It consumes
-CMS data and writes the generated site to the `dist/` directory. Run it with
-environment variables pointing at your Apps Script endpoint:
-
-```bash
-APPS_URL=<apps_script_url> APPS_KEY=<key> python tools/build.py
-```
-
-For local experiments a simplified variant is available at
-`tools/build_local.py`. It uses the same `APPS_URL` and `APPS_KEY` variables and
-also outputs to `dist/`.
+CMS data and writes the generated site to the `dist/` directory.
 
 ## CMS data
 

--- a/pages.yml
+++ b/pages.yml
@@ -3,8 +3,6 @@ version: 6
 # ============================ 1) CONSTANTS / KEYS ===========================
 constants:
   SITE_URL: "https://kras-trans.com"
-  APPS_URL: "https://script.google.com/macros/s/AKfycbyQcsU1wSCV6NGDQm8VIAGpZkL1rArZe1UZ5tutTkjJiKZtr4MjQZcDFzte26VtRJJ2KQ/exec"
-  APPS_KEY: "kb6mWQJQ3hTtY0m1GQ7v2rX1pC5n9d8zA4s6L2u"
   GA_ID: "G-5FYE42J3BE"
   GSC_HTML_FILE: "google4377ff145fac0f52.html"
   GSC_VERIFICATION: "Q3XgXOegwnvV6sBj31MbGlldhfD2uzmHBnR6kvLFj7Y"
@@ -49,8 +47,8 @@ site:
 
 # =============================== 3) CMS SOURCE ==============================
 cms:
-  endpoint: "${APPS_URL}"
-  key: "${APPS_KEY}"
+  endpoint: ""
+  key: ""
   expects:
     - ok
     - pages

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,6 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  <!-- CMS endpoint (dla headera, który ciągnie NAV z GAS) -->
-  <meta name="cms-endpoint" content="{{ cms_endpoint }}" />
 
   <title>{{ page.seo_title or page.title }}</title>
   <meta name="description" content="{{ page.meta_desc }}" />
@@ -151,10 +149,9 @@
   })();
   </script>
 
-  {# --- CMS_ENDPOINT stała (fallback do <meta>) --- #}
+  {# --- CMS_ENDPOINT stała --- #}
   <script>
-    window.CMS_ENDPOINT = window.CMS_ENDPOINT
-      || (document.querySelector('meta[name="cms-endpoint"]')?.content || '');
+    window.CMS_ENDPOINT = window.CMS_ENDPOINT || '';
   </script>
 
   {# --- Fallback: doładuj /assets/js/cms.js jeśli nie ma w assets.js --- #}

--- a/tools/build.py
+++ b/tools/build.py
@@ -9,11 +9,11 @@ CELE:
 - Zgodność z pages.yml v6, i18n (pl,en,de,fr,it,ru,ua), SEO, performance, a11y.
 
 NAJWAŻNIEJSZE FUNKCJE:
-- ENV override: SITE_URL, APPS_URL, APPS_KEY, GA_ID, GSC_VERIFICATION, INDEXNOW_KEY, BING_SITE_AUTH_USER, NEWS_ENABLED
-- CMS: pobieranie z Google Apps Script (?key=...), fallback do data/cms.json, robust timeout/log
+- ENV override: SITE_URL, GA_ID, GSC_VERIFICATION, INDEXNOW_KEY, BING_SITE_AUTH_USER, NEWS_ENABLED
+- CMS: wczytywanie z lokalnych plików data/cms, robust timeout/log
 - Kopiowanie assets/ → dist/assets
 - Render Jinja + autolinki + sanity DOM (a11y/perf)
-- Head injections (jeśli brakuje w szablonie): <meta name="cms-endpoint">, GA (gtag), GSC meta, canonical, hreflang, OG/Twitter, JSON-LD
+- Head injections (jeśli brakuje w szablonie): GA (gtag), GSC meta, canonical, hreflang, OG/Twitter, JSON-LD
 - Root "/" = redirect do /{defaultLang}/ + GSC meta + canonical
 - City×Service generator + thin/noindex + OG-image (opcjonalnie)
 - Sitemapy z alternates (xhtml:link), news-sitemap (okno godz.), robots.txt
@@ -267,8 +267,6 @@ def _env(name: str, default: Any) -> Any:
     return default if v is None or str(v).strip()=="" else v
 
 SITE_URL = (_env("SITE_URL", C.get("SITE_URL","")) or "").rstrip("/")
-APPS_URL = ""   # wyłączone: nie używamy Google Apps Script
-APPS_KEY = ""   # wyłączone: nie używamy Google Apps Script
 GA_ID    = _env("GA_ID", C.get("GA_ID",""))
 GSC      = _env("GSC_VERIFICATION", C.get("GSC_VERIFICATION",""))
 INDEXNOW_KEY = _env("INDEXNOW_KEY", C.get("INDEXNOW_KEY",""))
@@ -681,7 +679,7 @@ def og_image_for(page:Dict[str,Any])->Optional[str]:
 # ------------------------------ HEAD INJECTIONS -----------------------------
 def ensure_head_injections(soup:BeautifulSoup, page:Dict[str,Any], hreflang_map:Dict[str,Dict[str,str]]):
     """
-    Wstrzykuje: canonical, hreflang, OG/Twitter, GSC, cms-endpoint, GA, JSON-LD (jeśli brak).
+    Wstrzykuje: canonical, hreflang, OG/Twitter, GSC, GA, JSON-LD (jeśli brak).
     Bez duplikacji. Szanuje istniejące tagi z szablonów.
     """
     head = soup.find("head")
@@ -745,11 +743,6 @@ def ensure_head_injections(soup:BeautifulSoup, page:Dict[str,Any], hreflang_map:
     # GSC verification
     if (GSC or "").strip() and not head.find("meta", attrs={"name":"google-site-verification"}):
         add_meta(name="google-site-verification", content=GSC)
-
-    # cms-endpoint
-    cms_endpoint = (f"{APPS_URL}?key={APPS_KEY}" if APPS_URL and APPS_KEY else "")
-    if cms_endpoint and not head.find("meta", attrs={"name":"cms-endpoint"}):
-        add_meta(name="cms-endpoint", content=cms_endpoint)
 
     # GA (gtag) – wstrzykuj tylko, jeśli w całym dokumencie nie ma już configu
     if (GA_ID or "").strip():


### PR DESCRIPTION
## Summary
- drop obsolete APPS_URL/APPS_KEY constants and blank out CMS endpoint config
- stop injecting `<meta name="cms-endpoint">` and simplify CMS_ENDPOINT script
- update build documentation

## Testing
- `pytest`
- `python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87b2a00408333a5b37ecce7d7d460