### PR TITLE
Match menu scripts to navList ID

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -3,7 +3,7 @@
    - TYLKO sprawdza wersję bundla i w razie zmiany podmienia menu
    - pobiera z /assets/nav/bundle_{lang}.json (fix 404) */
 (function(){
-  const UL_ID = 'primary-nav-list';
+  const UL_ID = 'navList';
   const META_NAME = 'menu-bundle-version';
   const PREFIX = '/assets/nav';
 

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -3,7 +3,7 @@
    - TYLKO sprawdza wersję bundla i w razie zmiany podmienia menu
    - pobiera z /assets/nav/bundle_{lang}.json */
 (function(){
-  const UL_ID = 'primary-nav-list';
+  const UL_ID = 'navList';
   const META_NAME = 'menu-bundle-version';
   const PREFIX = '/assets/nav';
   const $ = s => document.querySelector(s);


### PR DESCRIPTION
## Summary
- Align menu loaders with existing `navList` element by setting `UL_ID` to `navList`

## Testing
- `pytest`
- `APPS_URL=https://example.com APPS_KEY=dummy python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8788d21788333a884c41fde9bfd6d