### PR TITLE
Enable Squarespace-style header

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,14 +51,16 @@
   <canvas id="bg-canvas" aria-hidden="true" hidden></canvas>
 
   <!-- HEADER: Nagłówek strony (sticky, przezroczysty z efektem rozmycia tła) -->
-  <header class="site-header">
+  <header id="site-header" class="site-header sq">
     <div class="container header-grid">
       <!-- Logo firmy -->
       <a class="brand" href="/">
         <img src="/assets/media/logo-firma-transportowa-kras-trans.png" alt="{{ company[0].name or 'Kras-Trans' }}" width="132" height="32" loading="eager" fetchpriority="high" />
       </a>
       <!-- Główna nawigacja (uzupełniana dynamicznie) -->
-      <nav id="site-nav" class="nav" hidden aria-label="{{ strings.nav_main or 'Główna nawigacja' }}"></nav>
+      <nav id="primaryNav" class="nav sq-nav" hidden aria-label="{{ strings.nav_main or 'Główna nawigacja' }}">
+        <ul class="nav__list" id="navList"></ul>
+      </nav>
       <div class="header-actions">
         <!-- Przycisk przełączania motywu (jasny/ciemny/e-book) -->
         <button id="theme-toggle" class="icon-btn theme-toggle" aria-label="{{ strings.theme_toggle or 'Zmień motyw' }}" aria-pressed="false">
@@ -69,7 +71,7 @@
       </div>
     </div>
     <!-- Mega Menu (desktop) - uzupełniane przez menu-builder.js -->
-    <div id="mega-root" class="mega" hidden></div>
+    <div id="mega" class="mega" hidden></div>
   </header>
 
   <main id="main" class="content" role="main">

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -3,7 +3,7 @@
      Mega-menu pełnej szerokości (grid + blog rail)
 ====================================================================================================== -->
 <header id="site-header"
-        class="site-header"
+        class="site-header sq"
         data-static="/assets/nav"
         data-theme-sun="/assets/flags/theme-sun.svg"
         data-theme-moon="/assets/flags/theme-moon.svg"
@@ -125,7 +125,7 @@
            src="/assets/media/logo-firma-transportowa-kras-trans.png" loading="eager" decoding="async">
     </a>
 
-    <nav id="primaryNav" class="nav" role="navigation" aria-label="Główne menu">
+    <nav id="primaryNav" class="nav sq-nav" role="navigation" aria-label="Główne menu">
       <ul class="nav__list" id="navList"><li><a href="/pl/">Start</a></li></ul>
     </nav>
 


### PR DESCRIPTION
## Summary
- activate Squarespace-like header by adding `sq` classes and required IDs
- update index page markup for nav and mega elements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89514658c833385a87e6a5531f9c8