### PR TITLE
feat: aggregate CMS files for build

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -30,7 +30,15 @@ UŻYCIE (CI):
 """
 import os
 from pathlib import Path
-import cms_ingest
+
+try:
+    import cms_ingest
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Missing dependency: cms_ingest. Ensure the local module exists in the "
+        "tools/ directory or install the package if it is external."
+    ) from exc
+
 from bs4 import BeautifulSoup
 
 import re, io, csv, json, math, sys, time, glob, shutil, hashlib, unicodedata, pathlib
@@ -814,8 +822,9 @@ def neighbors_for(
 # ------------------------------ RENDER / BUILD ------------------------------
 def build_all():
     languages = LOCALES
-    src = os.getenv("LOCAL_XLSX") or os.getenv("CMS_SOURCE") or "/Users/illia/Desktop/Kras_transStrona/CMS.xlsx"
-    cms = cms_ingest.load_all(Path("data") / "cms", explicit_src=Path(src))
+    src_env = os.getenv("LOCAL_XLSX") or os.getenv("CMS_SOURCE")
+    explicit = Path(src_env) if src_env else None
+    cms = cms_ingest.load_all(Path("data") / "cms", explicit_src=explicit)
     print(cms.get("report","[cms] no report"))
     global CMS
     CMS = cms

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -1,0 +1,52 @@
+"""Minimal CMS ingestion utilities for the site builder.
+
+This module provides a ``load_all`` function expected by ``tools/build.py``.
+It loads JSON data from a directory and returns it as a dictionary with a
+``report`` entry describing the source that was used.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Iterable
+
+
+def load_all(data_dir: Path, explicit_src: Optional[Path] = None) -> Dict[str, Any]:
+    """Load CMS data from ``data_dir``.
+
+    The loader aggregates all JSON files found in ``data_dir``. If
+    ``explicit_src`` is provided and exists, only that file is loaded. Data from
+    each JSON file is merged into a single dictionary. Non-dictionary payloads
+    are stored under a key derived from the file name.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the merged CMS data. A human readable
+        ``report`` entry describes which files were processed.
+    """
+
+    files: Iterable[Path]
+    if explicit_src and explicit_src.exists():
+        files = [explicit_src]
+    else:
+        files = sorted(data_dir.glob("*.json"))
+
+    data: Dict[str, Any] = {}
+    loaded = []
+    for path in files:
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                content = json.load(fh)
+            if isinstance(content, dict):
+                data.update(content)
+            else:
+                data[path.stem] = content
+            loaded.append(path.name)
+        except Exception as exc:  # pragma: no cover - error path
+            loaded.append(f"{path.name} (error: {exc})")
+
+    report = "[cms] loaded " + ", ".join(loaded) if loaded else "[cms] no data files found"
+    data.setdefault("report", report)
+    return data


### PR DESCRIPTION
## Summary
- aggregate all JSON files under data/cms during build
- ensure build.py passes optional CMS source from env vars

## Testing
- `python -m pytest`
- `python tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a89b0cefa8833398bd6c6254619a04