### PR TITLE
Fix 404 page link to respect default language

### DIFF
--- a/tests/test_404_home_link.py
+++ b/tests/test_404_home_link.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "tools"))
+
+from tools.build import write_404_page
+
+def test_404_uses_default_lang(tmp_path):
+    write_404_page(tmp_path, "en")
+    content = (tmp_path / "404.html").read_text("utf-8")
+    assert "href='/en/'" in content

--- a/tools/build.py
+++ b/tools/build.py
@@ -203,6 +203,11 @@ def write_text(p: pathlib.Path, s: str):
 def ensure_dir(p: pathlib.Path):
     p.mkdir(parents=True, exist_ok=True)
 
+def write_404_page(out_dir: pathlib.Path, default_lang: str):
+    """Generate a minimal 404 page linking to the site's home in the default language."""
+    home = f"/{default_lang}/" if default_lang else "/"
+    write_text(out_dir/"404.html", f"<h1>404</h1><p>Nie znaleziono strony. <a href='{home}'>Wróć do strony głównej</a>.</p>")
+
 def norm_slug(s: str) -> str:
     s = unicodedata.normalize("NFD", s or "").encode("ascii","ignore").decode("ascii")
     s = re.sub(r"&","-and-", s.lower())
@@ -1011,7 +1016,7 @@ def build_all():
         write_text(OUT / html_file, f"google-site-verification: {token}")
 
     # 404.html (prosty)
-    write_text(OUT/"404.html", "<h1>404</h1><p>Nie znaleziono strony. <a href='/pl/'>Wróć do strony głównej</a>.</p>")
+    write_404_page(OUT, DEFAULT_LANG)
 
     # robots.txt
     write_text(OUT/"robots.txt", f"User-agent: *\nAllow: /\nSitemap: {SITE_URL}/sitemap.xml\n")


### PR DESCRIPTION
## Summary
- generate 404 page links using the site's configured default language instead of a hard-coded Polish path
- add regression test to ensure the 404 page points to the default language home

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a79605308333ba3af3be36ab2dcc