### PR TITLE
Autogenerate pages from CMS and add generic template

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,13 +28,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt || pip install pyyaml openpyxl
 
-      - name: Copy CMS spreadsheet
+      - name: Provide CMS from runner
         run: |
+          set -euo pipefail
+          mkdir -p data/cms
           SRC="${{ vars.CMS_SOURCE }}"
-          if [ -z "$SRC" ]; then SRC="${{ vars.LOCAL_XLSX }}"; fi
           if [ -z "$SRC" ]; then SRC="/Users/illia/Desktop/Kras_transStrona/CMS.xlsx"; fi
-          mkdir -p data/cms && cp "$SRC" data/cms/menu.xlsx
-          shasum -a 256 data/cms/menu.xlsx | awk '{print "CMS_SHA256:",$1}'
+          echo "CMS_SOURCE_PATH: $SRC"
+          ls -lah "$(dirname "$SRC")" || true
+          if [ ! -f "$SRC" ]; then echo "❌ CMS not found at: $SRC"; exit 1; fi
+          cp "$SRC" data/cms/menu.xlsx
+          echo "CMS_SHA256: $(shasum -a 256 data/cms/menu.xlsx | awk '{print $1}')"
+          ls -lah data/cms
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/templates/pages/generic.html
+++ b/templates/pages/generic.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<section class="page-generic">
+  <div class="container">
+    <header class="page-header">
+      <h1>{{ meta.title }}</h1>
+      {% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}
+    </header>
+    <section data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></section>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- Improve GitHub Pages workflow to robustly copy CMS spreadsheet from runner
- Extend build script to load CMS, auto-generate missing pages, override metadata, feed menu, inject blocks, and log debug info
- Add generic page template used by auto-generated pages

## Testing
- `pytest -q`
- `python -m py_compile tools/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab677ebc833397a600768a3061f2