### PR TITLE
feat: scan all CMS sheets and guard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,6 +59,16 @@ jobs:
           source .venv/bin/activate
           python tools/cms_guard.py .codex/cms_schema.yml data/cms/menu.xlsx
 
+      - name: Upload CMS sheet report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cms-sheets
+          path: |
+            sheet_report.json
+            data/cms/menu.xlsx
+          if-no-files-found: warn
+
       - name: Build
         env:
           CLEAN: '1'

--- a/tools/cms_guard.py
+++ b/tools/cms_guard.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+from pathlib import Path
+from typing import List
+import sys
+
+
+def validate(schema_path: Path, xlsx_path: Path) -> None:
+    import openpyxl, yaml
+    _ = yaml.safe_load(schema_path.read_text(encoding="utf-8")) if schema_path.exists() else None
+    wb = openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)
+
+    def norm(s: str) -> str:
+        return (s or "").strip().lower()
+
+    content_like = 0
+    recognized = 0
+
+    for ws in wb.worksheets:
+        hdr = [str(c or "").strip() for c in next(ws.iter_rows(values_only=True))]
+        hdr_lc = [norm(h) for h in hdr]
+        print(f"[sheet] {ws.title}: {hdr}")
+
+        is_pages = "lang" in hdr_lc and "publish" in hdr_lc and ("slug" in hdr_lc or "slugkey" in hdr_lc) and "template" in hdr_lc
+        is_menu = "lang" in hdr_lc and "publish" in hdr_lc and "label" in hdr_lc and "href" in hdr_lc
+        is_meta = "lang" in hdr_lc and "key" in hdr_lc
+        is_blocks = "lang" in hdr_lc and ("html" in hdr_lc or "body" in hdr_lc)
+
+        if "lang" in hdr_lc and "publish" in hdr_lc:
+            if any(c in hdr_lc for c in ["slug", "slugkey", "template", "label", "href", "enabled", "html", "body", "key"]):
+                content_like += 1
+
+        if is_pages or is_menu or is_meta or is_blocks:
+            recognized += 1
+
+    print(f"[summary] content-like={content_like}, recognized={recognized}")
+    if recognized < content_like:
+        print("[cms_guard] ERROR: some content-like sheets not recognized")
+        sys.exit(1)
+
+    # zapis debug
+    try:
+        import json, os
+        rep = {"sheets":[{"name":ws.title,"headers":[str(c or "") for c in next(ws.iter_rows(values_only=True))]} for ws in wb.worksheets]}
+        Path("sheet_report.json").write_text(json.dumps(rep, ensure_ascii=False, indent=2), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("Usage: cms_guard.py <schema.yml> <xlsx>")
+        return 1
+    schema = Path(sys.argv[1])
+    xlsx = Path(sys.argv[2])
+    validate(schema, xlsx)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -67,69 +67,169 @@ def _find_sheet(sheets, group):
     return best if best_score >= 3 else None
 
 def load_all(cms_root: Path, explicit_src: Optional[Path]=None) -> Dict[str,Any]:
-    report=[]
-    # źródło
+    """
+    Skanuje KAŻDY arkusz XLSX i klasyfikuje go po nagłówkach:
+    - pages-like:  lang + publish + (slug|slugkey) + template  -> pages_rows + page_routes + page_meta
+    - menu-like :  lang + label + href + enabled               -> menu_rows
+    - meta-like :  lang + key                                  -> page_meta (uzupełnienie)
+    - blocks-like: lang + (html|body)                          -> blocks
+    Dane z wielu arkuszy sumują się (union).
+    """
+    report = []
+    # 1) wybór źródła
     src = explicit_src if explicit_src and explicit_src.exists() else \
-          (cms_root/"menu.xlsx" if (cms_root/"menu.xlsx").exists() else None)
-    if not src:
-        return {"menu_rows":[], "page_meta":{}, "blocks":{}, "report":"[cms] no source"}
-    report.append(f"[cms_ingest] source: {src}")
-    sheets = _read_xlsx(src)
+          (cms_root / "menu.xlsx" if (cms_root / "menu.xlsx").exists() else None)
+    if not src:  # CSV/JSON fallback
+        return {"menu_rows": [], "page_meta": {}, "blocks": {}, "page_routes": {}, "pages_rows": [], "report": "[cms] no source"}
 
+    report.append(f"[cms_ingest] source: {src}")
+
+    import openpyxl
+    wb = openpyxl.load_workbook(src, read_only=True, data_only=True)
+
+    def norm(s): return (s or "").strip().lower()
+    def headers(ws):
+        it = ws.iter_rows(values_only=True)
+        row = next(it)
+        return [str(x or "").strip() for x in row]
+
+    # akumulatory
     menu_rows: List[Dict[str,Any]] = []
     page_meta: Dict[str,Dict[str,Any]] = {}
     blocks: Dict[str,Dict[str,Any]] = {}
+    pages_rows: List[Dict[str,Any]] = []
+    routes: Dict[str, Dict[str, str]] = {}
 
-    sm = _find_sheet(sheets, "menu")
-    if sm:
-        report.append(f"[menu] sheet: {sm}")
-        for headers,row in _rows(sheets[sm]):
-            m = _map_headers(headers, SYN["menu"])
-            if not all(k in m for k in ("lang","label","href")): continue
-            g = lambda k: (row[m[k]] if k in m and m[k] < len(row) else "").strip()
-            lang=_lower(g("lang"))
-            menu_rows.append({
-              "lang": lang,
-              "label": g("label"),
-              "href":  g("href"),
-              "parent": g("parent"),
-              "order": int(float(g("order") or "999")),
-              "col":   int(float(g("col") or "1")),
-              "enabled": _lower(g("enabled")) in {"1","true","prawda","tak","yes","on"}
-            })
-        menu_rows = [r for r in menu_rows if r["enabled"]]
+    def truthy(v:str) -> bool:
+        return norm(v) in {"1","true","tak","yes","on","prawda"}
 
-    smeta = _find_sheet(sheets, "meta")
-    if smeta:
-        report.append(f"[meta] sheet: {smeta}")
-        for headers,row in _rows(sheets[smeta]):
-            m = _map_headers(headers, SYN["meta"])
-            if not all(k in m for k in ("lang","key")): continue
-            g = lambda k: (row[m[k]] if k in m and m[k] < len(row) else "").strip()
-            lang=_lower(g("lang")); key=_lower(g("key"))
-            d = page_meta.setdefault(lang, {}).setdefault(key, {})
-            if g("title"): d["title"]=g("title")
-            if g("description"): d["description"]=g("description")
-            if g("og_image"): d["og_image"]=g("og_image")
+    # przejrzyj wszystkie arkusze
+    for ws in wb.worksheets:
+        hdr = headers(ws); hdr_lc = [norm(h) for h in hdr]
+        r = f"[sheet] {ws.title}: {hdr}"
+        report.append(r)
 
-    sbl = _find_sheet(sheets, "blocks")
-    if sbl:
-        report.append(f"[blocks] sheet: {sbl}")
-        for headers,row in _rows(sheets[sbl]):
-            m = _map_headers(headers, SYN["blocks"])
-            if "lang" not in m: continue
-            g = lambda k: (row[m[k]] if k in m and m[k] < len(row) else "").strip()
-            lang=_lower(g("lang"))
-            path = g("path")
-            if not path:
-                key=_lower(g("key")); sec=_lower(g("section"))
-                if key and sec: path=f"pages/{key}/{sec}"
-            if not path: continue
-            b = blocks.setdefault(lang, {}).setdefault(path.lstrip("/"), {})
-            for fld in ("html","title","body","cta_label","cta_href"):
-                val=g(fld)
-                if val: b[fld]=val
+        # pomocnicy dopasowań
+        def has(*cols): return all(c in hdr_lc for c in cols)
+        def idx(name:str) -> int:
+            try: return hdr_lc.index(name)
+            except ValueError: return -1
+        def cell(row, name):
+            i = idx(name)
+            return (str(row[i]).strip() if i >= 0 and i < len(row) and row[i] is not None else "")
 
-    report.append(f"[result] menu_rows={len(menu_rows)}, meta_langs={len(page_meta)}, blocks_langs={len(blocks)}")
-    return {"menu_rows":menu_rows, "page_meta":page_meta, "blocks":blocks, "report":"\n".join(report)}
+        # klasyfikacja
+        is_pages = has("lang","publish","template") and (("slug" in hdr_lc) or ("slugkey" in hdr_lc))
+        is_menu  = has("lang","label","href","enabled")
+        is_meta  = has("lang","key")
+        is_blocks= has("lang") and ("html" in hdr_lc or "body" in hdr_lc)
+
+        it = ws.iter_rows(values_only=True); next(it, None)
+
+        if is_pages:
+            report.append(f"[detect] pages-like: {ws.title}")
+            for row in it:
+                L   = norm(cell(row,"lang") or "pl")
+                pub = truthy(cell(row,"publish") or "true")
+                if not pub: 
+                    continue
+                raw_slug = cell(row,"slug")
+                key = norm(cell(row,"slugkey") or "")
+                tpl = cell(row,"template") or "page.html"
+                par = cell(row,"parentslug") or cell(row,"parent") or ""
+                order = cell(row,"order") or "999"
+                # slug relatywny bez /{lang}/
+                rel = raw_slug.strip()
+                if rel.startswith(f"/{L}/"): rel = rel[len(f"/{L}/"):]
+                rel = rel.strip("/")
+                if not key: key = (rel or "home") if rel else "home"
+
+                # meta z kolumn pages (nie gub żadnej)
+                meta = {
+                    "h1": cell(row,"h1"),
+                    "title": cell(row,"title"),
+                    "seo_title": cell(row,"seo_title"),
+                    "meta_desc": cell(row,"meta_desc"),
+                    "hero_alt": cell(row,"hero_alt"),
+                    "hero_image": cell(row,"hero_image"),
+                    "og_image": cell(row,"og_image"),
+                    "canonical": cell(row,"canonical"),
+                    "cta_label": cell(row,"cta_label"),
+                    "cta_href": cell(row,"cta_href"),
+                    "cta_phone": cell(row,"cta_phone"),
+                    "whatsapp": cell(row,"whatsapp"),
+                }
+                # zapisz
+                pages_rows.append({
+                    "lang": L, "key": key, "slug": rel, "parent_key": par, "template": tpl,
+                    "order": int(float(order or "999")), "meta": meta
+                })
+                routes.setdefault(key, {})[L] = rel
+                pm = page_meta.setdefault(L, {}).setdefault(key, {})
+                # uzupełnij mapę meta (nie nadpisuj jeśli już istnieje z innego arkusza)
+                for k,v in (("seo_title","seo_title"),("title","title"),("meta_desc","description"),("og_image","og_image"),("canonical","canonical")):
+                    val = meta.get(k)
+                    if val and (pm.get(v) in (None,"")):
+                        pm[v] = val
+
+        if is_menu:
+            report.append(f"[detect] menu-like: {ws.title}")
+            for row in it:
+                L = norm(cell(row,"lang") or "pl")
+                lab = cell(row,"label"); href = cell(row,"href")
+                if not lab or not href: 
+                    continue
+                par = cell(row,"parent"); order = cell(row,"order") or "999"
+                col = cell(row,"col") or "1"; en = truthy(cell(row,"enabled") or "true")
+                if not en: 
+                    continue
+                menu_rows.append({
+                    "lang": L, "label": lab, "href": href,
+                    "parent": par, "order": int(float(order)), "col": int(float(col)), "enabled": True
+                })
+
+        if is_meta:
+            report.append(f"[detect] meta-like: {ws.title}")
+            for row in it:
+                L = norm(cell(row,"lang") or "pl")
+                key = norm(cell(row,"key") or "")
+                if not key: 
+                    continue
+                pm = page_meta.setdefault(L, {}).setdefault(key, {})
+                t = cell(row,"title") or cell(row,"seo_title")
+                d = cell(row,"description") or cell(row,"meta_desc")
+                og= cell(row,"og_image"); can = cell(row,"canonical")
+                if t: pm["title"]=t
+                if d: pm["description"]=d
+                if og: pm["og_image"]=og
+                if can: pm["canonical"]=can
+
+        if is_blocks:
+            report.append(f"[detect] blocks-like: {ws.title}")
+            for row in it:
+                L = norm(cell(row,"lang") or "pl")
+                path = cell(row,"path")
+                if not path:
+                    key = norm(cell(row,"key") or "")
+                    sec = norm(cell(row,"section") or "")
+                    if key and sec: path = f"pages/{key}/{sec}"
+                if not path: 
+                    continue
+                b = blocks.setdefault(L, {}).setdefault(path.lstrip("/"), {})
+                htm = cell(row,"html"); body= cell(row,"body")
+                if htm: b["html"]=htm
+                if body and not htm: b["body"]=body
+                for extra in ("title","cta_label","cta_href"):
+                    v = cell(row,extra)
+                    if v: b[extra]=v
+
+    report.append(f"[result] pages_rows={len(pages_rows)}, menu_rows={len(menu_rows)}, meta_langs={len(page_meta)}, blocks_langs={len(blocks)}")
+    return {
+        "menu_rows": menu_rows,
+        "page_meta": page_meta,
+        "blocks": blocks,
+        "page_routes": routes,
+        "pages_rows": pages_rows,
+        "report": "\n".join(report)
+    }
 


### PR DESCRIPTION
## Summary
- expand cms_ingest to scan every sheet and merge pages, menu, meta, blocks data
- add cms_guard to list sheets, validate content-like vs recognized and write sheet_report.json
- upload sheet report artifact in Pages workflow

## Testing
- `python tools/cms_guard.py .codex/cms_schema.yml data/cms/menu.xlsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c78c2c10833396e5096ec374ec23