### PR TITLE
Fix hero claim binding in page template

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -49,7 +49,7 @@
          data-api="/home/hero" aria-busy="{{ 'false' if ssr else 'true' }}">
   <div class="wrap hero__wrap">
     <div class="hero__copy">
-      <p class="hero__claim" data-bind="text: home.claim"></p>
+      <p class="hero__claim" data-bind="text: hero.claim">{{ H.claim if ssr and H.claim else '' }}</p>
       <h1 id="hero-title" class="hero__title">
         {{ H.title if ssr else '' }}
       </h1>


### PR DESCRIPTION
## Summary
- Correct hero claim variable binding and add SSR fallback for claim in page template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8dd60d0648333968ad294ec88e4a1