### PR TITLE
Normalize slugs without leading slash prefix in CMS ingestion

### DIFF
--- a/tests/test_cms_ingest.py
+++ b/tests/test_cms_ingest.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import openpyxl
+
+# Ensure project root is on the Python path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.cms_ingest import load_all
+
+
+def test_slug_without_leading_slash(tmp_path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "pages"
+    ws.append(["lang", "publish", "slug", "template"])
+    ws.append(["ua", "1", "ua/tsiny", "page.html"])
+    src = tmp_path / "test.xlsx"
+    wb.save(src)
+
+    result = load_all(cms_root=tmp_path, explicit_src=src)
+    assert result["pages_rows"][0]["slug"] == "tsiny"
+

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -163,8 +163,9 @@ def load_all(cms_root: Path, explicit_src: Optional[Path]=None) -> Dict[str,Any]
                 tpl = raw.get("template") or "page.html"
                 par = raw.get("parentSlug") or raw.get("parent") or ""
                 order = raw.get("order") or "999"
-                rel = raw_slug.strip()
-                if rel.startswith(f"/{L}/"): rel = rel[len(f"/{L}/"):]
+                rel = raw_slug.strip().lstrip("/")
+                if rel.startswith(f"{L}/"):
+                    rel = rel[len(f"{L}/"):]
                 rel = rel.strip("/")
                 if not key: key = (rel or "home") if rel else "home"
                 page = dict(raw)


### PR DESCRIPTION
## Summary
- Normalize page slugs by stripping language prefix with or without a leading slash
- Add unit test ensuring `ua/tsiny` is interpreted as `tsiny`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7f598a483338f9b823e0117ce1f