### PR TITLE
Fix CMS ingest for slugs missing leading language prefix slash

### DIFF
--- a/tests/test_cms_ingest.py
+++ b/tests/test_cms_ingest.py
@@ -21,3 +21,21 @@ def test_slug_without_leading_slash(tmp_path):
     result = load_all(cms_root=tmp_path, explicit_src=src)
     assert result["pages_rows"][0]["slug"] == "tsiny"
 
+
+def test_slug_without_leading_slash_generates_page_path(tmp_path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "pages"
+    ws.append(["lang", "publish", "slug", "template"])
+    ws.append(["ua", "1", "ua/tsiny", "page.html"])
+    src = tmp_path / "test.xlsx"
+    wb.save(src)
+
+    result = load_all(cms_root=tmp_path, explicit_src=src)
+    page = result["pages_rows"][0]
+    assert page["slug"] == "tsiny"
+    key = page["slugKey"]
+    slug = result["page_routes"][key]["ua"]
+    path = "/" + "/".join(filter(None, ["ua", slug])) + "/"
+    assert path == "/ua/tsiny/"
+

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -163,8 +163,10 @@ def load_all(cms_root: Path, explicit_src: Optional[Path]=None) -> Dict[str,Any]
                 tpl = raw.get("template") or "page.html"
                 par = raw.get("parentSlug") or raw.get("parent") or ""
                 order = raw.get("order") or "999"
-                rel = raw_slug.strip().lstrip("/")
-                if rel.startswith(f"{L}/"):
+                rel = raw_slug.strip()
+                if rel.startswith(f"/{L}/"):
+                    rel = rel[len(f"/{L}/"):]
+                elif rel.startswith(f"{L}/"):
                     rel = rel[len(f"{L}/"):]
                 rel = rel.strip("/")
                 if not key: key = (rel or "home") if rel else "home"


### PR DESCRIPTION
## Summary
- Normalize page slugs so both `/ua/tsiny/` and `ua/tsiny` map to `tsiny`
- Add regression test asserting derived page path `/ua/tsiny/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ea9bd56483339976e1e2539a8ed2