### PR TITLE
Fail build if language lacks home page

### DIFF
--- a/tests/test_build_requires_home_page.py
+++ b/tests/test_build_requires_home_page.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import openpyxl
+
+
+def test_build_fails_without_home(tmp_path):
+    # Prepare minimal project structure in a temp directory
+    (tmp_path / "templates").mkdir()
+    cms_dir = tmp_path / "data" / "cms"
+    cms_dir.mkdir(parents=True)
+    # Provide CMS data only for Polish home page
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "pages"
+    ws.append(["lang", "publish", "slug", "template"])
+    ws.append(["pl", "1", "", "page.html"])
+    wb.save(cms_dir / "menu.xlsx")
+
+    pages_yml = (
+        "languages: [pl, en]\n"
+        "site: { defaultLang: pl, locales: { pl: {}, en: {} } }\n"
+        "paths: { src: { templates: 'templates' }, out: 'dist' }\n"
+    )
+    (tmp_path / "pages.yml").write_text(pages_yml, encoding="utf-8")
+
+    build_script = Path(__file__).resolve().parents[1] / "tools" / "build.py"
+    result = subprocess.run(
+        [sys.executable, str(build_script)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "[build] No home page for language 'en'" in (result.stderr + result.stdout)

--- a/tools/build.py
+++ b/tools/build.py
@@ -405,6 +405,20 @@ def load_cms() -> Dict[str, Any]:
 
 CMS = load_cms()
 
+# Ensure each language has a home page before proceeding
+for _lang in CFG.get("languages") or []:
+    L = (_lang or DEFAULT_LANG).lower()
+    pages_for_lang = [
+        p for p in CMS.get("pages", [])
+        if (p.get("lang") or DEFAULT_LANG).lower() == L
+    ]
+    has_home = any(
+        (p.get("slugKey") or "").lower() == "home" or (p.get("slug") or "") == ""
+        for p in pages_for_lang
+    )
+    if not has_home:
+        raise RuntimeError(f"[build] No home page for language '{L}'")
+
 # ---------------------------- CSV: cities / keywords ------------------------
 def read_csv(path:str, dialect="auto")->List[Dict[str,str]]:
     p=pathlib.Path(path)


### PR DESCRIPTION
## Summary
- ensure build checks for a home page in every configured language
- add regression test to verify build fails when a language is missing its home page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8eaa987888333b00abf333a3eb875