### PR TITLE
Ensure default h1 generation for basic CMS pages

### DIFF
--- a/tests/test_auto_h1_generation.py
+++ b/tests/test_auto_h1_generation.py
@@ -1,0 +1,52 @@
+import os
+import importlib
+import sys
+from pathlib import Path
+
+import openpyxl
+
+
+def test_auto_h1_generation(tmp_path):
+    (tmp_path / "templates").mkdir()
+    cms_dir = tmp_path / "data" / "cms"
+    cms_dir.mkdir(parents=True)
+
+    # minimal template rendering h1
+    (tmp_path / "templates" / "page.html").write_text("<h1>{{ h1 }}</h1>", encoding="utf-8")
+
+    # CMS workbook with only basic columns
+    wb = openpyxl.Workbook()
+    ws_pages = wb.active
+    ws_pages.title = "pages"
+    ws_pages.append(["lang", "publish", "slug", "template"])
+    ws_pages.append(["pl", "1", "", "page.html"])  # home page
+    ws_pages.append(["pl", "1", "about", "page.html"])  # simple page
+
+    ws_menu = wb.create_sheet(title="menu")
+    ws_menu.append(["lang", "label", "href", "enabled"])
+    ws_menu.append(["pl", "Home", "/pl/", "1"])
+    wb.save(cms_dir / "menu.xlsx")
+
+    pages_yml = (
+        "languages: [pl]\n"
+        "site: { defaultLang: pl, locales: { pl: {} } }\n"
+        "paths: { src: { templates: 'templates' }, out: 'dist' }\n"
+        "templates: { page: 'page.html' }\n"
+    )
+    (tmp_path / "pages.yml").write_text(pages_yml, encoding="utf-8")
+
+    # Import build module using temp project as CWD
+    repo_tools = Path(__file__).resolve().parents[1] / "tools"
+    sys.path.append(str(repo_tools))
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        build = importlib.import_module("build")
+        pages = build.base_pages()
+        about = next(p for p in pages if p.get("slug") == "about")
+        html = build.env.get_template(about["template"]).render(h1=about["h1"], page=about)
+    finally:
+        os.chdir(cwd)
+        sys.modules.pop("build", None)
+
+    assert "<h1>about</h1>" in html

--- a/tools/build.py
+++ b/tools/build.py
@@ -496,6 +496,8 @@ def base_pages() -> List[Dict[str, Any]]:
         if not ctx.get("title"):
             ctx["title"] = (p.get("h1") or ctx["seo_title"])
 
+        ctx["h1"] = ctx.get("h1") or ctx["title"]
+
         ctx["template"] = choose_template(ctx)
         ctx["__from"] = p.get("__from", "pages")   # ← TEN wiersz zostaje
         pages.append(ctx)

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -180,6 +180,9 @@ def load_all(cms_root: Path, explicit_src: Optional[Path]=None) -> Dict[str,Any]
                     "order": int(float(order or "999")),
                     "publish": True
                 })
+                page.setdefault("h1", page["slugKey"])
+                page.setdefault("title", page["h1"])
+                page.setdefault("body_md", f"## {page['h1']}\n\n")
                 pages_rows.append(page)
                 routes.setdefault(key, {})[L] = rel
                 pm = page_meta.setdefault(L, {}).setdefault(key, {})


### PR DESCRIPTION
## Summary
- Default missing `h1`, `title`, and `body_md` fields for pages ingested from CMS
- Guarantee `ctx['h1']` in base page generation
- Add regression test validating autogenerated `h1`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ec706ed483338884fd363a7d830e