### PR TITLE
Stop reading trailing blank rows in CMS ingest

### DIFF
--- a/tests/test_cms_ingest.py
+++ b/tests/test_cms_ingest.py
@@ -22,7 +22,6 @@ def test_slug_without_leading_slash(tmp_path):
     assert result["pages_rows"][0]["slug"] == "tsiny"
 
 
-codex/add-warnings-for-missing-essential-text
 def test_missing_required_fields_warn(tmp_path):
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -39,3 +38,4 @@ def test_missing_required_fields_warn(tmp_path):
     assert f"[cms_ingest] page '{slug}' missing h1" in warnings
     assert f"[cms_ingest] page '{slug}' missing title" in warnings
     assert f"[cms_ingest] page '{slug}' missing body_md" in warnings
+

--- a/tests/test_cms_ingest_blank_rows.py
+++ b/tests/test_cms_ingest_blank_rows.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import openpyxl
+
+# Ensure project root on Python path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.cms_ingest import load_all
+
+
+def test_pages_ignore_trailing_blanks(tmp_path, monkeypatch):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "pages"
+    ws.append(["lang", "publish", "slug", "template"])
+    ws.append(["pl", "1", "/foo", "page.html"])
+    ws.append(["pl", "", "/bar", "page.html"])
+    for _ in range(1000):
+        ws.append([None, None, None, None])
+    src = tmp_path / "test.xlsx"
+    wb.save(src)
+
+    count = 0
+    original_iter_rows = openpyxl.worksheet.worksheet.Worksheet.iter_rows
+
+    def counting_iter_rows(self, *args, **kwargs):
+        nonlocal count
+        for row in original_iter_rows(self, *args, **kwargs):
+            count += 1
+            yield row
+
+    monkeypatch.setattr(openpyxl.worksheet.worksheet.Worksheet, "iter_rows", counting_iter_rows)
+
+    result = load_all(cms_root=tmp_path, explicit_src=src)
+    assert [p["slugKey"] for p in result["pages_rows"]] == ["foo"]
+    assert count < 50
+

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -153,10 +153,17 @@ def load_all(cms_root: Path, explicit_src: Optional[Path]=None) -> Dict[str,Any]
 
         if is_pages:
             report.append(f"[detect] pages-like: {ws.title}")
+            blank_rows = 0
             for row in it:
+                if all(cell in (None, "", " ") for cell in row):
+                    blank_rows += 1
+                    if blank_rows > 20:
+                        break
+                    continue
+                blank_rows = 0
                 raw = {hdr[i]: ("" if i>=len(row) or row[i] is None else str(row[i]).strip()) for i in range(len(hdr))}
                 L   = norm(raw.get("lang") or "pl")
-                pub = truthy(raw.get("publish") or "true")
+                pub = truthy(raw.get("publish", ""))
                 if not pub:
                     continue
                 raw_slug = raw.get("slug", "")


### PR DESCRIPTION
## Summary
- halt page ingestion after more than 20 consecutive blank rows
- require explicit truthy value in `publish` column before adding a page
- add regression test ensuring trailing blanks are skipped and only published rows are kept

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f092bbb08333ad69989fa49a5886