### PR TITLE
Limit worksheet iteration to used data range

### DIFF
--- a/tests/test_cms_ingest.py
+++ b/tests/test_cms_ingest.py
@@ -21,8 +21,6 @@ def test_slug_without_leading_slash(tmp_path):
     result = load_all(cms_root=tmp_path, explicit_src=src)
     assert result["pages_rows"][0]["slug"] == "tsiny"
 
-
-codex/add-warnings-for-missing-essential-text
 def test_missing_required_fields_warn(tmp_path):
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -39,3 +37,28 @@ def test_missing_required_fields_warn(tmp_path):
     assert f"[cms_ingest] page '{slug}' missing h1" in warnings
     assert f"[cms_ingest] page '{slug}' missing title" in warnings
     assert f"[cms_ingest] page '{slug}' missing body_md" in warnings
+
+
+def test_rows_respect_calculated_dimension():
+    from tools.cms_ingest import _rows
+
+    class FakeWs:
+        title = "Fake"
+        max_row = 9999
+
+        def calculate_dimension(self):
+            return "A1:B2"  # only two rows (header + one data row)
+
+        def iter_rows(self, values_only=True, max_row=None):
+            assert max_row == 2
+            data = [
+                ("h1", "h2"),
+                ("r1c1", "r1c2"),
+                ("extra", "row"),
+            ]
+            for row in data[:max_row]:
+                yield row
+
+    rows = list(_rows(FakeWs()))
+    assert len(rows) == 1
+    assert rows[0][1] == ["r1c1", "r1c2"]

--- a/tools/build.py
+++ b/tools/build.py
@@ -349,10 +349,12 @@ def _cms_local_read() -> Dict[str, Any]:
             import openpyxl
             wb = openpyxl.load_workbook(p_xlsx, read_only=True, data_only=True)
             ws = wb.worksheets[0]
+            start_cell, end_cell = ws.calculate_dimension().split(":")
+            max_row = int("".join(filter(str.isdigit, end_cell)))
             headers = [str(c.value).strip() if c.value is not None else "" for c in next(ws.iter_rows(min_row=1, max_row=1))]
             idx = {h: i for i, h in enumerate(headers)}
             rows = []
-            for row in ws.iter_rows(min_row=2, values_only=True):
+            for row in ws.iter_rows(min_row=2, values_only=True, max_row=max_row):
                 d = {h: (row[idx[h]] if h in idx else "") for h in headers}
                 rows.append({(k or "").strip(): (str(v or "").strip()) for k, v in d.items()})
             print(f"[CMS] Lokalnie: {p_xlsx}")

--- a/tools/cms_guard.py
+++ b/tools/cms_guard.py
@@ -17,7 +17,9 @@ def validate(schema_path: Path, xlsx_path: Path) -> None:
     recognized = 0
 
     for ws in wb.worksheets:
-        hdr = [str(c or "").strip() for c in next(ws.iter_rows(values_only=True))]
+        start_cell, end_cell = ws.calculate_dimension().split(":")
+        max_row = int("".join(filter(str.isdigit, end_cell)))
+        hdr = [str(c or "").strip() for c in next(ws.iter_rows(values_only=True, max_row=max_row))]
         hdr_lc = [norm(h) for h in hdr]
         print(f"[sheet] {ws.title}: {hdr}")
 
@@ -41,7 +43,11 @@ def validate(schema_path: Path, xlsx_path: Path) -> None:
     # zapis debug
     try:
         import json, os
-        rep = {"sheets":[{"name":ws.title,"headers":[str(c or "") for c in next(ws.iter_rows(values_only=True))]} for ws in wb.worksheets]}
+        def _hdr(ws):
+            start_cell, end_cell = ws.calculate_dimension().split(":")
+            max_row = int("".join(filter(str.isdigit, end_cell)))
+            return [str(c or "") for c in next(ws.iter_rows(values_only=True, max_row=max_row))]
+        rep = {"sheets":[{"name":ws.title,"headers":_hdr(ws)} for ws in wb.worksheets]}
         Path("sheet_report.json").write_text(json.dumps(rep, ensure_ascii=False, indent=2), encoding="utf-8")
     except Exception:
         pass

--- a/tools/generate_nav_from_xlsx.py
+++ b/tools/generate_nav_from_xlsx.py
@@ -31,13 +31,15 @@ def _to_bool(v: str) -> bool:
     return s in {'true','1','yes','y','tak','prawda'}
 
 def read_routes(ws):
+    start_cell, end_cell = ws.calculate_dimension().split(":")
+    max_row = int("".join(filter(str.isdigit, end_cell)))
     head = [c.value for c in ws[1]]
     try: idx_slug = head.index('slugKey')
     except ValueError:
         raise SystemExit("[Routes] Missing 'slugKey' header")
     langs = [h for h in head if h and h.lower() in LOCALES]
     routes = {}
-    for row in ws.iter_rows(min_row=2, values_only=True):
+    for row in ws.iter_rows(min_row=2, values_only=True, max_row=max_row):
         slug_key = (row[idx_slug] or '').strip()
         if not slug_key: continue
         m = {}
@@ -50,6 +52,8 @@ def read_routes(ws):
     return routes
 
 def read_props(ws):
+    start_cell, end_cell = ws.calculate_dimension().split(":")
+    max_row = int("".join(filter(str.isdigit, end_cell)))
     props = defaultdict(dict)  # props[lang][key] = value
     head = [c.value for c in ws[1]]
     try:
@@ -58,7 +62,7 @@ def read_props(ws):
         i_val  = head.index('value')
     except ValueError:
         raise SystemExit("[Props] Expected headers: key, lang, value")
-    for row in ws.iter_rows(min_row=2, values_only=True):
+    for row in ws.iter_rows(min_row=2, values_only=True, max_row=max_row):
         key  = (row[i_key]  or '').strip()
         lang = (row[i_lang] or '').strip().lower()
         val  = (row[i_val]  or '').strip()
@@ -67,6 +71,8 @@ def read_props(ws):
     return props
 
 def read_nav(ws):
+    start_cell, end_cell = ws.calculate_dimension().split(":")
+    max_row = int("".join(filter(str.isdigit, end_cell)))
     head = [c.value for c in ws[1]]
     idx = {}
     for h in ('lang','label','href','parent','order','enabled'):
@@ -79,7 +85,7 @@ def read_nav(ws):
 
     per_lang = defaultdict(list)
     seen_href = defaultdict(set)
-    for row in ws.iter_rows(min_row=2, values_only=True):
+    for row in ws.iter_rows(min_row=2, values_only=True, max_row=max_row):
         lang = (row[idx['lang']] or '').strip().lower()
         if lang not in LOCALES:
             continue

--- a/tools/menu_builder.py
+++ b/tools/menu_builder.py
@@ -73,6 +73,8 @@ def _load_xlsx(p: Path) -> List[Dict[str, Any]]:
         raise SystemExit("Do odczytu XLSX zainstaluj: pip install openpyxl  — lub zapisz CMS jako JSON/CSV.") from e
     wb = openpyxl.load_workbook(p, read_only=True, data_only=True)
     ws = wb.worksheets[0]
+    start_cell, end_cell = ws.calculate_dimension().split(":")
+    max_row = int("".join(filter(str.isdigit, end_cell)))
     headers = [str(c.value).strip() if c.value is not None else "" for c in next(ws.iter_rows(min_row=1, max_row=1))]
     idx = {h:i for i,h in enumerate(headers)}
     req = ["lang","label","href","parent","order","col","enabled"]
@@ -80,7 +82,7 @@ def _load_xlsx(p: Path) -> List[Dict[str, Any]]:
         if r not in idx:
             raise SystemExit(f"Brak kolumny '{r}' w {p.name}")
     rows = []
-    for row in ws.iter_rows(min_row=2, values_only=True):
+    for row in ws.iter_rows(min_row=2, values_only=True, max_row=max_row):
         d = {h: row[idx[h]] for h in req}
         rows.append(d)
     return rows

--- a/usr/bin/env
+++ b/usr/bin/env
@@ -84,7 +84,9 @@ def _map_headers(headers: List[str], group: str) -> Tuple[Dict[str,int], List[st
     return out, hl
 
 def _read_sheet_headers(ws) -> List[str]:
-    it = ws.iter_rows(values_only=True)
+    start_cell, end_cell = ws.calculate_dimension().split(":")
+    max_row = int("".join(filter(str.isdigit, end_cell)))
+    it = ws.iter_rows(values_only=True, max_row=max_row)
     headers = next(it)
     return [str(x or "").strip() for x in headers]
 
@@ -142,8 +144,10 @@ def validate(schema_path: Path, xlsx_path: Path) -> int:
         return 1
 
     # statystyki per lang + publikowalne wiersze
-    it = ws.iter_rows(values_only=True)
-    next(it)  # skip header
+      start_cell, end_cell = ws.calculate_dimension().split(":")
+      max_row = int("".join(filter(str.isdigit, end_cell)))
+      it = ws.iter_rows(values_only=True, max_row=max_row)
+      next(it)  # skip header
     langs, published = {}, {}
     for row in it:
         get = lambda name: (str(row[mapping[name]]).strip() if name in mapping and mapping[name] < len(row) and row[mapping[name]] is not None else "")


### PR DESCRIPTION
## Summary
- Determine each worksheet's actual data range via `calculate_dimension` and pass `max_row` to `iter_rows`
- Apply data range limiting across ingestion and helper scripts
- Add unit test verifying iteration stops at calculated row count

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f08fdb8c8333938c6843ae1e426d