### PR TITLE
Handle unsized worksheets in cms_guard

### DIFF
--- a/tests/test_cms_guard.py
+++ b/tests/test_cms_guard.py
@@ -1,0 +1,31 @@
+import re
+import sys
+import zipfile
+import openpyxl
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.cms_guard import validate
+
+
+def test_unsized_sheet(tmp_path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "pages"
+    ws.append(["lang", "publish", "slug", "template"])
+    base = tmp_path / "base.xlsx"
+    wb.save(base)
+
+    unsized = tmp_path / "unsized.xlsx"
+    with zipfile.ZipFile(base, "r") as zin, zipfile.ZipFile(unsized, "w") as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename == "xl/worksheets/sheet1.xml":
+                data = re.sub(br"<dimension ref=\"[^\"]*\"/>", b"", data)
+            zout.writestr(item, data)
+
+    schema = tmp_path / "schema.yml"
+    schema.write_text("{}", encoding="utf-8")
+
+    validate(schema, unsized)

--- a/tools/cms_guard.py
+++ b/tools/cms_guard.py
@@ -17,7 +17,7 @@ def validate(schema_path: Path, xlsx_path: Path) -> None:
     recognized = 0
 
     for ws in wb.worksheets:
-        start_cell, end_cell = ws.calculate_dimension().split(":")
+        start_cell, end_cell = ws.calculate_dimension(force=True).split(":")
         max_row = int("".join(filter(str.isdigit, end_cell)))
         hdr = [str(c or "").strip() for c in next(ws.iter_rows(values_only=True, max_row=max_row))]
         hdr_lc = [norm(h) for h in hdr]
@@ -44,7 +44,7 @@ def validate(schema_path: Path, xlsx_path: Path) -> None:
     try:
         import json, os
         def _hdr(ws):
-            start_cell, end_cell = ws.calculate_dimension().split(":")
+            start_cell, end_cell = ws.calculate_dimension(force=True).split(":")
             max_row = int("".join(filter(str.isdigit, end_cell)))
             return [str(c or "") for c in next(ws.iter_rows(values_only=True, max_row=max_row))]
         rep = {"sheets":[{"name":ws.title,"headers":_hdr(ws)} for ws in wb.worksheets]}


### PR DESCRIPTION
## Summary
- avoid openpyxl `Worksheet is unsized` errors by forcing dimension calculation
- add regression test for unsized worksheet handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f231a1dc83339460091204a799f9