### PR TITLE
Add CMS snapshot tool

### DIFF
--- a/sheet_report.json
+++ b/sheet_report.json
@@ -1,0 +1,387 @@
+{
+  "sheets": [
+    {
+      "name": "_lists",
+      "headers": [
+        "name",
+        "vals"
+      ]
+    },
+    {
+      "name": "Pages",
+      "headers": [
+        "lang",
+        "type",
+        "slug",
+        "slugKey",
+        "parentSlug",
+        "template",
+        "publish",
+        "order",
+        "h1",
+        "title",
+        "seo_title",
+        "meta_desc",
+        "hero_alt",
+        "hero_image",
+        "og_image",
+        "canonical_path",
+        "cta_label",
+        "cta_secondary",
+        "cta_phone",
+        "cta_whatsapp",
+        "lead",
+        "body_md",
+        "min_outlinks",
+        "max_outlinks",
+        "structured_data",
+        "links_suggest",
+        "city",
+        "service",
+        "hero_video",
+        "tags",
+        "service_languages",
+        "secondary_keywords",
+        "anchor_text_suggestions",
+        "structured_data_types"
+      ]
+    },
+    {
+      "name": "Nav",
+      "headers": [
+        "lang",
+        "label",
+        "href",
+        "parent",
+        "order",
+        "col",
+        "enabled",
+        "nav.logo.src",
+        "nav.logo.alt",
+        "nav.cta.label",
+        "nav.cta.slugKey",
+        "nav.status.label",
+        "nav.status.href",
+        "nav.social.ig",
+        "nav.social.li",
+        "nav.social.fb"
+      ]
+    },
+    {
+      "name": "props",
+      "headers": [
+        "key",
+        "lang",
+        "value"
+      ]
+    },
+    {
+      "name": "Routes",
+      "headers": [
+        "slugKey",
+        "pl",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "ru",
+        "ua"
+      ]
+    },
+    {
+      "name": "Strings",
+      "headers": [
+        "key",
+        "pl",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "ru",
+        "ua",
+        "uk"
+      ]
+    },
+    {
+      "name": "FAQ",
+      "headers": [
+        "lang",
+        "q",
+        "a",
+        "page_slug",
+        "order",
+        "enabled",
+        "Kolumna nr 7",
+        "Kolumna nr 8",
+        "Kolumna nr 9",
+        "Kolumna nr 10"
+      ]
+    },
+    {
+      "name": "_report",
+      "headers": [
+        "sheet",
+        "lang",
+        "rowA",
+        "rowB",
+        "field",
+        "sim",
+        "valueA",
+        "valueB"
+      ]
+    },
+    {
+      "name": "Media",
+      "headers": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "name": "Company",
+      "headers": [
+        "name",
+        "legal_name",
+        "telephone",
+        "phone",
+        "address",
+        "country",
+        "email",
+        "website",
+        null
+      ]
+    },
+    {
+      "name": "Leady",
+      "headers": [
+        "created_at",
+        "name",
+        "phone",
+        "email",
+        "message",
+        "source",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign"
+      ]
+    },
+    {
+      "name": "Blocks",
+      "headers": [
+        "block",
+        "lang",
+        "page",
+        "type",
+        "title",
+        "body_md",
+        "desc",
+        "href",
+        "order",
+        "lead",
+        "body_md",
+        "cta_label",
+        "cta_href",
+        "enabled"
+      ]
+    },
+    {
+      "name": "Templates",
+      "headers": [
+        "name",
+        "description"
+      ]
+    },
+    {
+      "name": "Arkusz15",
+      "headers": [
+        "sheet",
+        "lang",
+        "rowA",
+        "rowB",
+        "field",
+        "sim",
+        "valueA",
+        "valueB"
+      ]
+    },
+    {
+      "name": "Places",
+      "headers": [
+        "slug",
+        "type",
+        "name",
+        "lang",
+        "title",
+        "h1",
+        "lead",
+        "meta_desc"
+      ]
+    },
+    {
+      "name": "Reviews",
+      "headers": [
+        "source",
+        "author",
+        "rating",
+        "text",
+        "date",
+        "url",
+        "lang"
+      ]
+    },
+    {
+      "name": "CaseStudies",
+      "headers": [
+        "lang",
+        "slug",
+        "title",
+        "lead",
+        "meta_desc",
+        "body_md",
+        "category",
+        "date"
+      ]
+    },
+    {
+      "name": "Locations",
+      "headers": [
+        "lang",
+        "slug",
+        "city",
+        "street",
+        "postal",
+        "country",
+        "phone",
+        "opening_hours",
+        "body_md"
+      ]
+    },
+    {
+      "name": "Jobs",
+      "headers": [
+        "publish",
+        "lang",
+        "slug",
+        "title",
+        "location",
+        "type",
+        "salary",
+        "body_md",
+        "active"
+      ]
+    },
+    {
+      "name": "AutoLinks",
+      "headers": [
+        "lang",
+        "from_type",
+        "match",
+        "target_href",
+        "anchor",
+        "max_per_page",
+        "nofollow",
+        "priority"
+      ]
+    },
+    {
+      "name": "Redirects",
+      "headers": [
+        "from",
+        "to",
+        "code"
+      ]
+    },
+    {
+      "name": "SEO_Stats",
+      "headers": [
+        "url",
+        "lighthouse_desktop",
+        "lighthouse_mobile",
+        "cls",
+        "lcp",
+        "inp",
+        "timestamp"
+      ]
+    },
+    {
+      "name": "README",
+      "headers": [
+        "Kras-Trans CMS PRO (xlsx) — instrukcja",
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "name": "Blog",
+      "headers": [
+        "publish",
+        "lang",
+        "slug",
+        "slugKey",
+        "title",
+        "h1",
+        "lead",
+        "body_md",
+        "seo_title",
+        "meta_desc",
+        "og_image",
+        "hero_image",
+        "authorSlug",
+        "categories",
+        "tags",
+        "published_at",
+        "updated_at",
+        "template"
+      ]
+    },
+    {
+      "name": "Categories",
+      "headers": [
+        "slug",
+        "name",
+        "description",
+        "lang",
+        "parent"
+      ]
+    },
+    {
+      "name": "Authors",
+      "headers": [
+        "slug",
+        "name",
+        "job_title",
+        "bio_md",
+        "avatar",
+        "website",
+        "twitter",
+        "linkedin"
+      ]
+    }
+  ],
+  "rows_per_lang": {
+    "pl": 84,
+    "en": 81,
+    "de": 71,
+    "fr": 73,
+    "it": 71,
+    "ru": 70,
+    "ua": 69
+  },
+  "published_per_lang": {
+    "pl": 7,
+    "en": 12,
+    "de": 5,
+    "fr": 7,
+    "it": 5,
+    "ru": 4,
+    "ua": 3
+  }
+}

--- a/tools/cms_snapshot.py
+++ b/tools/cms_snapshot.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate snapshot report for CMS XLSX file."""
+import json
+import os
+import sys
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from openpyxl import load_workbook
+
+LANG_HEADERS = {"lang", "język", "jezyk"}
+TRUE_VALUES = {"true", "1", "yes", "tak", "on"}
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value == 1
+    if isinstance(value, str):
+        return value.strip().lower() in TRUE_VALUES
+    return False
+
+def main(path: Optional[str] = None) -> None:
+    # Resolve path from argument or environment variable
+    if path is None:
+        path = os.environ.get("CMS_SOURCE")
+    if not path:
+        print("Usage: python tools/cms_snapshot.py <xlsx_path>", file=sys.stderr)
+        sys.exit(1)
+
+    wb = load_workbook(path, read_only=True, data_only=True)
+
+    sheets: List[Dict[str, Any]] = []
+    rows_per_lang: Counter[str] = Counter()
+    published_per_lang: Counter[str] = Counter()
+
+    for ws in wb.worksheets:
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        sheets.append({"name": ws.title, "headers": headers})
+        print(f"{ws.title}: {headers}")
+
+        header_map = {
+            (str(h).casefold() if isinstance(h, str) else None): idx
+            for idx, h in enumerate(headers)
+        }
+
+        # locate language and publish columns
+        lang_idx = None
+        for alias in LANG_HEADERS:
+            idx = header_map.get(alias.casefold())
+            if idx is not None:
+                lang_idx = idx
+                break
+        publish_idx = header_map.get("publish")
+
+        if lang_idx is None:
+            continue
+
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            if lang_idx >= len(row):
+                continue
+            lang_val = row[lang_idx]
+            if not lang_val:
+                continue
+            lang = str(lang_val).strip()
+            if not lang.isalpha():
+                continue
+            rows_per_lang[lang] += 1
+            if publish_idx is not None and publish_idx < len(row):
+                if _truthy(row[publish_idx]):
+                    published_per_lang[lang] += 1
+
+    report = {
+        "sheets": sheets,
+        "rows_per_lang": dict(rows_per_lang),
+        "published_per_lang": dict(published_per_lang),
+    }
+
+    with open("sheet_report.json", "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    main(arg)


### PR DESCRIPTION
## Summary
- add cms_snapshot tool to inspect CMS XLSX files and create snapshot report
- store snapshot in sheet_report.json with sheet headers and per-language stats

## Testing
- `python tools/cms_snapshot.py data/cms/menu.xlsx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9079ae5e88333958e874a9fe4cd79