### PR TITLE
Add CMS route diagnostics and fix auto-page build summary

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -78,6 +78,19 @@ jobs:
           source .venv/bin/activate
           python tools/build.py
 
+      - name: DIAG routes
+        run: |
+          set -e
+          python tools/diag_routes.py
+        continue-on-error: true
+
+      - name: Upload diag
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: diag-cms
+          path: _diag_cms.json
+
       - name: Verify build
         run: |
           set -e

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -1,0 +1,1 @@
+<!doctype html><section class="page"><div class="container"><h1>{{ meta.title }}</h1>{% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}<div data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></div></div></section>

--- a/tools/build.py
+++ b/tools/build.py
@@ -929,7 +929,7 @@ def build_all():
     # --- REBUILD ROUTING PO AUTOGENIE ---
     _build_pages = page_list  # to jest nasza aktualna lista stron
     slugs = { p["key"]: p["slugs"] for p in _build_pages }   # <-- odświeżone slugs
-    print(f"[cms] pages autogen: total_keys={len(slugs)}; after_merge={len(_build_pages)}")
+    print(f"[cms] pages autogen: keys={len(slugs)}; langs={len(languages)}")
 
     # helper path_for korzystający z aktualnych slugs
     def path_for(key: str, lang: str) -> str:

--- a/tools/diag_routes.py
+++ b/tools/diag_routes.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+import json, yaml, sys
+sys.path.append("tools")
+import cms_ingest
+
+
+def main():
+    site = yaml.safe_load((Path("data")/"site.yml").read_text("utf-8"))
+    dlang = site.get("default_lang","pl")
+    cms   = cms_ingest.load_all(Path("data")/"cms")
+    routes = cms.get("page_routes") or {}
+    rows   = cms.get("pages_rows") or []
+
+    # required paths tylko dla type in {page, home} i publish=TRUE
+    def truthy(v): return str(v or "").strip().lower() in {"1","true","tak","yes","on","prawda"}
+    required = []
+    for r in rows:
+        typ = (r.get("type") or "page").strip().lower()
+        pub = truthy((r.get("meta") or {}).get("publish","true"))
+        if not pub or typ not in {"page","home"}: 
+            continue
+        L   = r.get("lang") or dlang
+        rel = r.get("slug") or ""
+        p = Path("dist")/L/(rel or "")/"index.html"
+        required.append(str(p))
+
+    # co faktycznie istnieje
+    built = [str(p) for p in Path("dist").rglob("index.html")]
+
+    report = {
+        "langs_from_cms": sorted({r.get("lang","pl") for r in rows}),
+        "routes_keys": sorted(routes.keys()),
+        "required_count": len(required),
+        "missing": sorted([p for p in required if p not in built])[:500],  # max 500 dla logu
+        "built_count": len(built),
+    }
+    Path("_diag_cms.json").write_text(json.dumps(report, ensure_ascii=False, indent=2), "utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `diag_routes.py` to report CMS routes vs built pages
- integrate diagnostic step and artifact upload into Pages workflow
- log auto-generated page stats and ensure default page template exists

## Testing
- `python tools/build.py` *(fails: BeautifulSoup.new_tag() got multiple values for argument 'name')*
- `python tools/diag_routes.py`
- `python tools/cms_verify_build.py` *(fails: Missing outputs because build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a97c4c846083339b0556d81edebbad