### PR TITLE
Export CMS routes and verify build outputs

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<section class="page"><div class="container">
+  <h1>{{ meta.title }}</h1>
+  {% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}
+  <div data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></div>
+</div></section>

--- a/tools/cms_verify_build.py
+++ b/tools/cms_verify_build.py
@@ -1,60 +1,49 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Post-build verifier for CMS-driven pages and menus.
-
-This script checks only CMS entries that should be published, i.e. those with
-``publish = TRUE`` and ``type`` being either ``page`` or ``home``. For each of
-these rows we expect a corresponding ``index.html`` in the ``dist`` tree. It
-also verifies the presence of a menu bundle for the default language.
-"""
-
 from pathlib import Path
-import sys
-import yaml
-
-# Ensure we can import helpers from ``tools`` when executed from repository root
+import sys, json, yaml
 sys.path.append("tools")
 import cms_ingest
 
+OK="✅ Verify:"; ERR="❌ Verify:"
 
-OK = "✅ Verify:"
-ERR = "❌ Verify:"
-
-
-def main() -> None:
-    site = yaml.safe_load((Path("data") / "site.yml").read_text("utf-8"))
-    dlang = site.get("default_lang", "pl")
-
-    cms = cms_ingest.load_all(Path("data") / "cms")
-    rows = cms.get("pages_rows") or []
-
+def main():
+    routes_file = Path("_routes.json")
     required = []
-    for r in rows:
-        typ = (r.get("type") or "page").strip().lower()
-        pub = str(r.get("publish", True)).strip().lower()
-        if pub in {"1", "true", "tak", "yes", "on", "prawda"} and typ in {"page", "home"}:
-            lang = r.get("lang") or dlang
-            rel = cms_ingest._norm_slug(lang, r.get("slug") or "")
-            dst = Path("dist") / lang / (rel or "") / "index.html"
-            required.append(dst)
+
+    if routes_file.exists():
+        data = json.loads(routes_file.read_text("utf-8"))
+        for r in data:
+            out = Path(r.get("out",""))
+            if out.suffix == ".html":
+                required.append(out)
+    else:
+        site = yaml.safe_load((Path("data")/"site.yml").read_text("utf-8"))
+        dlang = site.get("default_lang","pl")
+        cms   = cms_ingest.load_all(Path("data")/"cms")
+        rows  = cms.get("pages_rows") or []
+        def truthy(v): return str(v or "").strip().lower() in {"1","true","tak","yes","on","prawda"}
+        for r in rows:
+            typ = (r.get("type") or "page").strip().lower()
+            pub = truthy((r.get("meta") or {}).get("publish","true"))
+            if not pub or typ not in {"page","home"}:
+                continue
+            L   = r.get("lang") or dlang
+            rel = r.get("slug") or ""
+            required.append(Path("dist")/L/(rel or "")/"index.html")
 
     missing = [str(p) for p in required if not p.exists()]
     if missing:
-        print(f"Missing outputs ({len(missing)}):")
-        for p in missing[:100]:
-            print(" ", p)
+        print("Missing outputs:"); [print(" ", p) for p in missing[:200]]
         sys.exit(1)
 
-    has_bundle = (
-        (Path("dist/assets/data/menu") / f"bundle_{dlang}.json").exists()
-        or (Path("dist/assets/nav") / f"bundle_{dlang}.json").exists()
-    )
+    site = yaml.safe_load((Path("data")/"site.yml").read_text("utf-8"))
+    dlang = site.get("default_lang","pl")
+    has_bundle = (Path("dist/assets/data/menu")/f"bundle_{dlang}.json").exists() \
+                 or (Path("dist/assets/nav")/f"bundle_{dlang}.json").exists()
     if not has_bundle:
         sys.exit(f"{ERR} no menu bundle for default language")
 
     print(f"{OK} pages & bundles OK")
 
-
-if __name__ == "__main__":
+if __name__=="__main__":
     main()
-


### PR DESCRIPTION
## Summary
- union CMS-provided languages and autogenerate page definitions
- rebuild routing helpers and export `_routes.json`
- add build verifier based on `_routes.json` and provide a fallback page template

## Testing
- `python tools/build.py`
- `python tools/cms_verify_build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9c68e71848333ac564ce1bac77f89