### PR TITLE
feat: persist build routes and use during verify

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -1147,18 +1147,16 @@ def build_all():
             )
             outdir = DIST / L / (slug if slug else "")
             outdir.mkdir(parents=True, exist_ok=True)
-            dest = outdir / "index.html"
-            dest.write_text(page_html, "utf-8")
-            print(f"[write] {L}{'/' + slug if slug else ''} -> {dest}")
-            generated.append({"key": key, "lang": L, "rel": slug, "out": str(dest)})
+            out_path = outdir / "index.html"
+            out_path.write_text(page_html, "utf-8")
+            print(f"[write] {L}/{slug or ''} -> {out_path}")
+            generated.append({"lang": L, "key": key, "rel": slug, "out": str(out_path)})
             if not page.get("noindex"):
                 indexables.append((SITE_URL + canonical, page.get("lastmod") or today, key))
             logs.append(f"{L}/{slug or ''} [{page.get('__from','pages')}] warns=-")
             writes += 1
 
-    from pathlib import Path as _P, PurePosixPath
-    import json as _J
-    _P("_routes.json").write_text(_J.dumps(generated, ensure_ascii=False, indent=2), "utf-8")
+    Path("_routes.json").write_text(json.dumps(generated, ensure_ascii=False, indent=2), "utf-8")
     print(f"[pages] writes={writes}")
     print(f"[routes] exported by build count={len(generated)}")
 

--- a/tools/cms_verify_build.py
+++ b/tools/cms_verify_build.py
@@ -1,38 +1,54 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
-import sys, yaml
+import sys, json, yaml
 sys.path.append("tools")
 import cms_ingest
 
 OK = "✅ Verify:"; ERR = "❌ Verify:"
 
 def main():
-    cms = cms_ingest.load_all(Path("data")/"cms")
-    routes = cms.get("page_routes") or {}
+    routes_file = Path("_routes.json")
     required = []
-    for key, per_lang in routes.items():
-        for lang, rel in per_lang.items():
-            required.append(Path("dist")/lang/(rel or "")/"index.html")
+
+    if routes_file.exists() and routes_file.stat().st_size > 2:
+        data = json.loads(routes_file.read_text("utf-8"))
+        for r in data:
+            out = Path(r.get("out", ""))
+            if out.suffix == ".html":
+                required.append(out)
+    else:
+        # Fallback: tylko type in {page,home} publish=TRUE
+        site = yaml.safe_load((Path("data")/"site.yml").read_text("utf-8"))
+        dlang = site.get("default_lang", "pl")
+        cms   = cms_ingest.load_all(Path("data")/"cms")
+        rows  = cms.get("pages_rows") or []
+        def truthy(v):
+            return str(v or "").strip().lower() in {"1","true","tak","yes","on","prawda"}
+        for r in rows:
+            typ = (r.get("type") or "page").strip().lower()
+            pub = truthy((r.get("meta") or {}).get("publish", "true"))
+            if not pub or typ not in {"page", "home"}:
+                continue
+            L   = r.get("lang") or dlang
+            rel = r.get("slug") or ""
+            required.append(Path("dist")/L/(rel or "")/"index.html")
 
     missing = [str(p) for p in required if not p.exists()]
     if missing:
-        print("Missing outputs:"); [print(" ", p) for p in missing[:200]]
-        sys.exit(1)
-
-    total_routes = sum(len(v) for v in routes.values())
-    existing = len(required) - len(missing)
-    if existing < total_routes:
         print("Missing outputs:")
+        for p in missing[:200]:
+            print(" ", p)
         sys.exit(1)
 
+    # bundle check (new/legacy)
     site = yaml.safe_load((Path("data")/"site.yml").read_text("utf-8"))
-    dlang = site.get("default_lang","pl")
-    has_bundle = (Path("dist/assets/data/menu")/f"bundle_{dlang}.json").exists() \
-                 or (Path("dist/assets/nav")/f"bundle_{dlang}.json").exists()
+    dlang = site.get("default_lang", "pl")
+    has_bundle = (Path("dist/assets/data/menu")/f"bundle_{dlang}.json").exists() or (Path("dist/assets/nav")/f"bundle_{dlang}.json").exists()
     if not has_bundle:
         sys.exit(f"{ERR} no menu bundle for default language")
 
     print(f"{OK} pages & bundles OK")
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- log every generated page and persist route info to `_routes.json`
- verify build outputs from `_routes.json` with CMS fallback

## Testing
- `python tools/build.py`
- `python tools/cms_verify_build.py` *(fails: Missing outputs)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3ace58188333a3a4f5cd7564fd0d