### PR TITLE
Use explicit title and H1 variables

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  <title>{{ page.seo_title or page.title }}</title>
+  <title>{{ title or (page.seo_title or page.title or site.brand) }}</title>
   <meta name="description" content="{{ page.meta_desc }}" />
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <section class="page"><div class="container">
-  <h1>{{ meta.title }}</h1>
+  <h1>{{ h1 or page.h1 or page.title }}</h1>
   {% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}
   <div data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></div>
 </div></section>


### PR DESCRIPTION
## Summary
- Set document title to `{{ title or (page.seo_title or page.title or site.brand) }}`
- Render page header using `{{ h1 or page.h1 or page.title }}` and drop meta-based title

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa480a824c83338bb717f42960c5fc