### PR TITLE
Add conditional blog post list to page template

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -2,5 +2,23 @@
 <section class="page"><div class="container">
   <h1>{{ h1 or page.h1 or page.title }}</h1>
   {% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}
+  {% if blog_posts and blog_posts|length > 0 %}
+  <section class="blog-list">
+    {% for p in blog_posts %}
+      <article class="post-card">
+        <h2>
+          <a href="{{ '/' ~ lang ~ '/' ~ p.slug|trim('/') ~ '/' }}">{{ p.title }}</a>
+        </h2>
+        {% if p.lead %}<p class="lead">{{ p.lead }}</p>{% endif %}
+        {% if p.published_at or p.author %}
+          <p class="meta">
+            {% if p.published_at %}<time>{{ p.published_at }}</time>{% endif %}
+            {% if p.author %} • {{ p.author }}{% endif %}
+          </p>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </section>
+  {% endif %}
   <div data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></div>
 </div></section>


### PR DESCRIPTION
## Summary
- display blog posts below the page lead when `blog_posts` are provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa493d41688333bc3e8ee64746d712