### PR TITLE
feat: add blog listing and detail rendering

### DIFF
--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<main>
+{% for post in posts %}
+  <a href="/{{lang}}/blog/{{ post.slug }}/">{{ post.h1 or post.title }}</a>
+{% endfor %}
+</main>
+{% endblock %}


### PR DESCRIPTION
## Summary
- load Blog sheet entries and group by language
- render /<lang>/blog/ listing and individual blog detail pages
- provide simple blog listing template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4e95a468833385eeb2dc7352d6d5