### PR TITLE
Handle missing referrer policy in templates and build script

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="referrer" content="{{ site.privacy.referrerPolicy or 'strict-origin-when-cross-origin' }}" />
+  <meta name="referrer"
+        content="{{ site.get('privacy', {}).get('referrerPolicy', 'strict-origin-when-cross-origin') }}" />
   <meta name="color-scheme" content="light dark" />
   <!-- Theme color per scheme (bez migotania paska adresu) -->
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />

--- a/tools/build.py
+++ b/tools/build.py
@@ -195,6 +195,8 @@ def write_text(p: Path, s: str):
 write = write_text
 
 SITE = read_yaml(DATA/"site.yml") if (DATA/"site.yml").exists() else {}
+SITE.setdefault("privacy", {})
+SITE["privacy"].setdefault("referrerPolicy", "strict-origin-when-cross-origin")
 
 def ensure_dir(p: pathlib.Path):
     p.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Safely access optional `site.privacy.referrerPolicy` in base template
- Provide defaults for `site.privacy.referrerPolicy` when loading site config

## Testing
- `python -u tools/build.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aabb0af60c8333a05f74cf9a9657ae