### PR TITLE
Defensive site metadata access

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ page.lang or site.defaultLang or 'pl' }}" class="no-js" data-color-scheme="light dark">
+<html lang="{{ page.lang or site.get('defaultLang', 'pl') }}" class="no-js" data-color-scheme="light dark">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="IE=edge" />
@@ -11,8 +11,13 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  <title>{{ title or (page.seo_title or page.title or site.brand) }}</title>
-  <meta name="description" content="{{ page.meta_desc }}" />
+  <title>
+    {{ page.seo_title
+       or page.title
+       or (site.get('brand') or {}).get('name')
+       or 'Kras‑Trans' }}
+  </title>
+  <meta name="description" content="{{ page.meta_desc or (site.get('brand') or {}).get('description', '') }}" />
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />
 
@@ -33,15 +38,15 @@
 
   {# --- OG / Twitter --- #}
   <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="{{ site.brand or 'Kras-Trans' }}" />
+  <meta property="og:site_name" content="{{ (site.get('brand') or {}).get('name') or 'Kras‑Trans' }}" />
   <meta property="og:url" content="{{ page.canonical or canonical }}" />
-  <meta property="og:title" content="{{ page.seo_title or page.title }}" />
-  <meta property="og:description" content="{{ page.meta_desc }}" />
-  <meta property="og:image" content="{{ (site.url or site.base_url) ~ (page.og_image or '/assets/media/og-default.webp') }}" />
+  <meta property="og:title" content="{{ page.seo_title or page.title or (site.get('brand') or {}).get('name') or 'Kras‑Trans' }}" />
+  <meta property="og:description" content="{{ page.meta_desc or (site.get('brand') or {}).get('description', '') }}" />
+  <meta property="og:image" content="{{ (site.get('url') or site.get('base_url') or '') ~ (page.og_image or '/assets/media/og-default.webp') }}" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="{{ page.seo_title or page.title }}" />
-  <meta name="twitter:description" content="{{ page.meta_desc }}" />
-  <meta name="twitter:image" content="{{ (site.url or site.base_url) ~ (page.og_image or '/assets/media/og-default.webp') }}" />
+  <meta name="twitter:title" content="{{ page.seo_title or page.title or (site.get('brand') or {}).get('name') or 'Kras‑Trans' }}" />
+  <meta name="twitter:description" content="{{ page.meta_desc or (site.get('brand') or {}).get('description', '') }}" />
+  <meta name="twitter:image" content="{{ (site.get('url') or site.get('base_url') or '') ~ (page.og_image or '/assets/media/og-default.webp') }}" />
 
   {# --- Ikony (bez 404 – tylko to, co faktycznie masz) --- #}
   {% set has_favicon = assets.icons and assets.icons.favicon %}


### PR DESCRIPTION
## Summary
- Guard against missing site config in base template
- Add safe fallbacks for titles, descriptions, and OG/Twitter meta data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aac15de5a08333a775ccba5b886747