### PR TITLE
front-fix pack: basic content without JS

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -62,10 +62,12 @@ img,svg,video{max-width:100%; height:auto; display:block}
 
 body.nav-open{overflow:hidden}
 
-/* CSR-only hiding: sekcje "busy" chowamy dopiero gdy JS ustawi data-csr="true" na <body> */
-body[data-csr="true"] [aria-busy="true"]{
-  display:none !important;
-}
+/* CSR-only hiding: sekcje ukrywamy dopiero gdy JS zgłosi gotowość */
+body[data-csr="true"] [aria-busy="true"]{ display:none }
+
+/* fallbacky no-SSR, żeby mieć zawsze jakąś wysokość i widoczność */
+.lead{font-size:clamp(16px,2vw,18px);color:var(--muted,#555)}
+.content{max-width:72ch}
 
 /* ---------------- LAYOUT HELPERS ---------------- */
 .wrap{max-width:var(--wrap); margin-inline:auto; padding-inline:var(--pad)}
@@ -233,10 +235,10 @@ body[data-csr="true"] [aria-busy="true"]{
 }
 
 /* ================= HERO / CARDS / GRIDS ================= */
-.section--hero{padding-top:32px}
+.section--hero{padding-top:32px;min-height:40vh}
 .hero__wrap{display:grid; gap:16px; align-items:center}
 @media (min-width:1024px){ .hero__wrap{grid-template-columns:1.1fr .9fr; gap:24px} }
-.hero__title{font-size:var(--h1); line-height:1.1; margin:0 0 8px}
+.hero__title,.page__title{font-size:clamp(28px,4vw,40px);line-height:1.1;margin:.5rem 0 1rem}
 .hero__lead{font-size:clamp(17px,1.4vw,20px); color:var(--muted); margin:0 0 16px}
 .hero__kpi{display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px; padding:0; margin:16px 0 0; list-style:none}
 .hero__kpi li{display:grid; grid-template-columns:auto 1fr; align-items:baseline; gap:10px; background:rgba(0,0,0,.035); padding:10px 12px; border-radius:var(--radius)}

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,12 +33,8 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  <title>
-    {{ page.seo_title
-       or page.title
-       or _og_title
-       or _brand_name }}
-  </title>
+  {# bezpieczny tytuł: preferuj seo_title, potem h1/title, w ostateczności brand #}
+  <title>{{ page.seo_title or page.h1 or page.title or _og_title or _brand_name }}</title>
   <meta name="description" content="{{ page.meta_desc or _meta_desc }}" />
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />
@@ -200,6 +196,15 @@
       else { window.addEventListener('load', loadGA, {once:true}); }
     })('{{ ga_id }}');
   </script>
+  {% endif %}
+
+  {# dopisz lekki debug overlay – włącza się querystringiem ?debug=1 #}
+  {% if request and request.args and request.args.get('debug') %}
+  <style>
+    .debug-banner{position:fixed;inset:auto 0 0 0;background:#111;color:#0f0;
+    font:12px/1.4 ui-monospace,monospace;padding:.5rem 1rem;z-index:9999;opacity:.9}
+  </style>
+  <div class="debug-banner">DEBUG: lang={{ lang }} • canonical={{ canonical }} • tpl={{ template if template is defined else '' }}</div>
   {% endif %}
 
   <noscript><style>.site-header{position:sticky}.reel{scroll-snap-type:none}</style></noscript>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
+{# bezpieczny alias na rekord strony #}
+{% set pg = pg or page or {} %}
 {# =========================
    KRAS-TRANS • HOME (SSR+CSR)
    - Zero widocznych tekstów „na sztywno”
@@ -49,11 +51,9 @@
         data-api="/home/hero" aria-busy="false">
   <div class="wrap hero__wrap">
     <div class="hero__copy">
-      <p class="hero__claim" data-bind="text: hero.claim">{{ H.claim if ssr and H.claim else '' }}</p>
-      <h1 id="hero-title" class="hero__title">
-        {{ H.title if ssr else '' }}
-      </h1>
-      <p class="hero__lead">{{ H.lead if ssr else '' }}</p>
+      <p class="hero__claim" data-bind="text: hero.claim">{{ (H.claim if ssr and H.claim else pg.lead) or '' }}</p>
+      <h1 id="hero-title" class="hero__title">{{ (H.title if ssr else (pg.h1 or pg.title)) or title }}</h1>
+      <p class="hero__lead">{{ (H.lead if ssr else (pg.lead or meta_desc)) or '' }}</p>
 
       <div class="cta-row">
         <a class="btn btn-primary"

--- a/templates/pages/generic.html
+++ b/templates/pages/generic.html
@@ -1,10 +1,9 @@
-<!doctype html>
-<section class="page-generic">
-  <div class="container">
-    <header class="page-header">
-      <h1>{{ meta.title }}</h1>
-      {% if meta.description %}<p class="lead">{{ meta.description }}</p>{% endif %}
-    </header>
-    <section data-api="/pages/{{ page.key }}/body?lang={{ lang }}"></section>
-  </div>
-</section>
+{% extends "base.html" %}
+{% block content %}
+<main class="wrap" aria-busy="false">
+  <h1 class="page__title">{{ pg.h1 or pg.title or title }}</h1>
+  {% if pg.lead %}<p class="lead">{{ pg.lead }}</p>{% endif %}
+  {% if page_html %}<article class="content">{{ page_html|safe }}</article>
+  {% elif pg.body_md %}<article class="content">{{ pg.body_md }}</article>{% endif %}
+</main>
+{% endblock %}


### PR DESCRIPTION
## Summary
- ensure safe fallback titles and debug overlay in base template
- render home hero and generic pages without SSR/JS data
- add CSS fallbacks and adjust section visibility rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacb9d87248333ae69ebae6012808a