### PR TITLE
Add core scripts to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,5 +236,8 @@
     /* Globalna konfiguracja menu z CMS (wstawiana podczas build) */
     window.KRAS_NAV = {{ nav_cfg | tojson }};
   </script>
+  <script defer src="/assets/js/site.js"></script>
+  <script defer src="/assets/js/cms.js"></script>
+  <script defer src="/assets/js/menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Include site.js and CMS scripts at end of index template for dynamic content
- Load optional menu.js alongside to support navigation

## Testing
- `pytest -q`
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68aad00afd448333a511badc0a077e30