### PR TITLE
Integrate new CMS variables and blog templates

### DIFF
--- a/pages.yml
+++ b/pages.yml
@@ -87,8 +87,8 @@ templates:
   header: "templates/header.html"
   page: "templates/page.html"
   location: "templates/location.html"
-  blog_index: "templates/blog_index.html"
-  blog_post: "templates/blog_post.html"
+  blog_index: "templates/pages/blog.html"
+  blog_post: "templates/pages/blog_post.html"
   reviews: "templates/reviews.html"
   jobs_index: "templates/jobs_index.html"
   job_item: "templates/job_item.html"
@@ -100,8 +100,8 @@ template_rules:
     service:     "templates/page.html"
     city_service: "templates/location.html"
     contact:     "templates/page.html"
-    blog:        "templates/blog_index.html"
-    blog_post:   "templates/blog_post.html"
+    blog:        "templates/pages/blog.html"
+    blog_post:   "templates/pages/blog_post.html"
     job:         "templates/job_item.html"
   by_slugKey:
     pricing: "templates/page.html"
@@ -109,7 +109,7 @@ template_rules:
     contact: "templates/page.html"
   by_slug_pattern:
     - { match: "^uslugi/.+$", template: "templates/page.html" }
-    - { match: "^blog/.+$",   template: "templates/blog_post.html" }
+    - { match: "^blog/.+$",   template: "templates/pages/blog_post.html" }
 
 # =============================== ASSETS ===============================
 assets:
@@ -194,8 +194,8 @@ collections:
       service:     "templates/page.html"
       city_service: "templates/location.html"
       contact:     "templates/page.html"
-      blog:        "templates/blog_index.html"
-      blog_post:   "templates/blog_post.html"
+      blog:        "templates/pages/blog.html"
+      blog_post:   "templates/pages/blog_post.html"
       job:         "templates/job_item.html"
     output: { pattern: "/{lang}/{slug}/", ensureTrailingSlash: true }
     seo:

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,13 @@
 {# `site` bywa stringiem — normalizujemy do dict #}
 {% set _site = site if site is mapping else {} %}
 
+{# `company` z arkusza może być listą lub dict – normalizujemy #}
+{% set _company = (
+  company[0] if company is sequence and company|length > 0
+  else company if company is mapping
+  else {}
+) %}
+
 {# brand może być dict albo string #}
 {% set _brand_obj = _site.get('brand') %}
 {% if _brand_obj is mapping %}
@@ -38,6 +45,9 @@
   <meta name="description" content="{{ page.meta_desc or _meta_desc }}" />
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />
+
+  {% if _company.telephone %}<meta name="telephone" content="{{ _company.telephone }}" />{% endif %}
+  {% if _company.email %}<meta name="email" content="{{ _company.email }}" />{% endif %}
 
   {# --- HREFLANG (z buildera) --- #}
   {% if alternates %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,6 +2,15 @@
 {% block content %}
 {# bezpieczny alias na rekord strony #}
 {% set pg = pg or page or {} %}
+{% set _slug = pg.slugKey or pg.slug or page.slugKey or page.slug or '' %}
+{% set _lang = pg.lang or page.lang or site.defaultLang or 'pl' %}
+{% set BLOCKS = (
+  blocks|selectattr('enabled','ne',False)
+        |selectattr('page','equalto',_slug)
+        |selectattr('lang','equalto',_lang)
+        |sort(attribute='order')
+        |list
+) if blocks is defined else [] %}
 {# =========================
    KRAS-TRANS • HOME (SSR+CSR)
    - Zero widocznych tekstów „na sztywno”
@@ -116,6 +125,35 @@
   </div>
   <div class="divider divider--bottom"></div>
 </section>
+
+{% if pg.body_md or pg.cta_label or pg.cta_secondary or pg.cta_phone or pg.cta_whatsapp %}
+<section id="page-body" class="section section--content">
+  <div class="wrap">
+    {% if pg.body_md %}<article class="content" data-md>{{ pg.body_md }}</article>{% endif %}
+    {% if pg.cta_label or pg.cta_secondary or pg.cta_phone or pg.cta_whatsapp %}
+    <div class="cta-row">
+      {% if pg.cta_label %}<a class="btn btn-primary" href="{{ pg.cta_href or '#' }}">{{ pg.cta_label }}</a>{% endif %}
+      {% if pg.cta_secondary %}<a class="btn btn-ghost" href="{{ href_by_slugkey('contact') }}">{{ pg.cta_secondary }}</a>{% endif %}
+      {% if pg.cta_phone %}<a class="btn btn-ghost" href="tel:{{ pg.cta_phone }}">{{ pg.cta_phone }}</a>{% endif %}
+      {% if pg.cta_whatsapp %}<a class="btn btn-ghost" href="https://wa.me/{{ pg.cta_whatsapp }}">WhatsApp</a>{% endif %}
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endif %}
+
+{% for blk in BLOCKS %}
+<section class="section block block--{{ blk.block }}" id="block-{{ loop.index }}" aria-labelledby="block-{{ loop.index }}-title">
+  <div class="wrap">
+    {% if blk.title %}<h2 id="block-{{ loop.index }}-title">{{ blk.title }}</h2>{% endif %}
+    {% if blk.lead %}<p class="lead">{{ blk.lead }}</p>{% endif %}
+    {% if blk.body_md %}<div class="content" data-md>{{ blk.body_md }}</div>{% endif %}
+    {% if blk.cta_label and blk.cta_href %}
+      <div class="cta-row"><a class="btn btn-primary" href="{{ blk.cta_href }}">{{ blk.cta_label }}</a></div>
+    {% endif %}
+  </div>
+</section>
+{% endfor %}
 
 {# ================================================================
    1) SERVICES — kafle, reel na mobile

--- a/templates/pages/blog_post.html
+++ b/templates/pages/blog_post.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="wrap" aria-busy="false">
+  <h1 class="post__title">{{ pg.h1 or pg.title or title }}</h1>
+  {% if pg.lead %}<p class="lead">{{ pg.lead }}</p>{% endif %}
+  {% if pg.date %}<p class="post__meta"><time datetime="{{ pg.date }}">{{ pg.date }}</time></p>{% endif %}
+  {% if page_html %}<div class="content">{{ page_html|safe }}</div>
+  {% elif pg.body_md %}<div class="content" data-md>{{ pg.body_md }}</div>{% endif %}
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Include company info and contact meta tags in base layout
- Render page markdown, CTAs and Blocks-based sections in the page template
- Provide dedicated blog post template and update routing to use it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aadb7954048333884e2a518dc47f0c