### PR TITLE
Provide fallback content for data-bound templates

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -60,20 +60,20 @@
         data-api="/home/hero" aria-busy="false">
   <div class="wrap hero__wrap">
     <div class="hero__copy">
-      <p class="hero__claim" data-bind="text: hero.claim">{{ (H.claim if ssr and H.claim else pg.lead) or '' }}</p>
+      <p class="hero__claim" data-bind="text: hero.claim">{{ (H.claim if ssr and H.claim else pg.lead) or 'Mocne hasło' }}</p>
       <h1 id="hero-title" class="hero__title">{{ (H.title if ssr else (pg.h1 or pg.title)) or title }}</h1>
-      <p class="hero__lead">{{ (H.lead if ssr else (pg.lead or meta_desc)) or '' }}</p>
+      <p class="hero__lead">{{ (H.lead if ssr else (pg.lead or meta_desc)) or 'Krótki opis' }}</p>
 
       <div class="cta-row">
         <a class="btn btn-primary"
            href="{{ href_by_slugkey('quote') }}"
            data-bind="href: hero.cta_primary.slugKey|slug, text: hero.cta_primary.label">
-          {{ H.cta_primary.label if ssr else '' }}
+          {{ H.cta_primary.label if ssr else 'Poznaj ofertę' }}
         </a>
         <a class="btn btn-ghost"
            href="{{ href_by_slugkey('contact') }}"
            data-bind="href: hero.cta_secondary.slugKey|slug, text: hero.cta_secondary.label">
-           {{ H.cta_secondary.label if ssr else '' }}
+           {{ H.cta_secondary.label if ssr else 'Skontaktuj się' }}
         </a>
         {% if company and company[0] and company[0].telephone %}
           <a class="btn btn-ghost"
@@ -93,7 +93,7 @@
         {% else %}
           {# CSR: cztery puste sloty do wypełnienia #}
           {% for i in range(0,4) %}
-            <li role="listitem"><strong data-bind="text: hero.kpi[{{ i }}].value"></strong><span data-bind="text: hero.kpi[{{ i }}].label"></span></li>
+            <li role="listitem"><strong data-bind="text: hero.kpi[{{ i }}].value">0</strong><span data-bind="text: hero.kpi[{{ i }}].label">KPI</span></li>
           {% endfor %}
         {% endif %}
       </ul>
@@ -103,9 +103,9 @@
       <picture>
         {# Możesz mieć srcset w JSON; JS podmieni, a builder doda preload #}
         <img id="heroLCP" width="1280" height="720" decoding="async" loading="eager" fetchpriority="high"
-             src="{{ H.image.src if ssr else '' }}"
+             src="{{ H.image.src if ssr else 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=' }}"
              srcset="{{ H.image.srcset if ssr else '' }}"
-             alt="{{ H.image.alt if ssr else '' }}"
+             alt="{{ H.image.alt if ssr else 'Obraz' }}"
              data-bind="attr: { src: hero.image.src, srcset: hero.image.srcset, alt: hero.image.alt }">
       </picture>
       <div class="hero__backdrop">
@@ -170,7 +170,7 @@
       </p>
     </header>
 
-    <div class="reel services__reel" role="list" aria-label="" data-bind="aria: { label: home.aria_services }">
+    <div class="reel services__reel" role="list" aria-label="Usługi" data-bind="aria: { label: home.aria_services }">
       {% if ssr and ssr.services %}
         {% for s in ssr.services %}
           {% set href = ssr.routes[s.slugKey][page.lang] if ssr.routes.get(s.slugKey) else '/' ~ (page.lang or 'pl') ~ '/' ~ s.slugKey ~ '/' %}
@@ -185,10 +185,10 @@
         {# CSR placeholder: 8 slotów #}
         {% for i in range(0,8) %}
           <article class="card card--service" role="listitem">
-            <div class="card__icon" aria-hidden="true" data-bind="html: services[{{ i }}].icon"></div>
-            <h3 class="card__title" data-bind="text: services[{{ i }}].title"></h3>
-            <p class="card__desc" data-bind="text: services[{{ i }}].desc"></p>
-            <a class="card__link" data-bind="href: services[{{ i }}].slugKey|slug, text: services[{{ i }}].cta.label"></a>
+            <div class="card__icon" aria-hidden="true" data-bind="html: services[{{ i }}].icon">&#128663;</div>
+            <h3 class="card__title" data-bind="text: services[{{ i }}].title">Tytuł usługi</h3>
+            <p class="card__desc" data-bind="text: services[{{ i }}].desc">Opis usługi</p>
+            <a class="card__link" data-bind="href: services[{{ i }}].slugKey|slug, text: services[{{ i }}].cta.label">Poznaj usługę</a>
           </article>
         {% endfor %}
       {% endif %}
@@ -218,8 +218,8 @@
       {% else %}
         {% for i in range(0,6) %}
           <article class="tile3d" role="listitem">
-            <h3 data-bind="text: industries[{{ i }}].title"></h3>
-            <p data-bind="text: industries[{{ i }}].desc"></p>
+            <h3 data-bind="text: industries[{{ i }}].title">Branża</h3>
+            <p data-bind="text: industries[{{ i }}].desc">Opis branży</p>
           </article>
         {% endfor %}
       {% endif %}
@@ -248,8 +248,8 @@
       {% else %}
         {% for i in range(0,6) %}
           <article class="card card--ghost" role="listitem">
-            <h3 class="card__title" data-bind="text: coverage[{{ i }}].title"></h3>
-            <p class="card__desc" data-bind="text: coverage[{{ i }}].desc"></p>
+            <h3 class="card__title" data-bind="text: coverage[{{ i }}].title">Region</h3>
+            <p class="card__desc" data-bind="text: coverage[{{ i }}].desc">Opis regionu</p>
           </article>
         {% endfor %}
       {% endif %}
@@ -278,8 +278,8 @@
       {% else %}
         {% for i in range(0,6) %}
           <li class="step" role="listitem">
-            <h3 data-bind="text: process[{{ i }}].title"></h3>
-            <p data-bind="text: process[{{ i }}].desc"></p>
+            <h3 data-bind="text: process[{{ i }}].title">Etap</h3>
+            <p data-bind="text: process[{{ i }}].desc">Opis etapu</p>
           </li>
         {% endfor %}
       {% endif %}
@@ -309,9 +309,9 @@
       {% else %}
         {% for i in range(0,6) %}
           <article class="kpi" role="listitem">
-            <div class="kpi__value" data-bind="text: trust[{{ i }}].value"></div>
-            <div class="kpi__label" data-bind="text: trust[{{ i }}].label"></div>
-            <p class="kpi__desc" data-bind="text: trust[{{ i }}].desc"></p>
+            <div class="kpi__value" data-bind="text: trust[{{ i }}].value">100%</div>
+            <div class="kpi__label" data-bind="text: trust[{{ i }}].label">Wskaźnik</div>
+            <p class="kpi__desc" data-bind="text: trust[{{ i }}].desc">Opis wskaźnika</p>
           </article>
         {% endfor %}
       {% endif %}
@@ -343,10 +343,10 @@
       {% else %}
         {% for i in range(0,6) %}
           <figure class="quote card card--quote" role="listitem">
-            <blockquote class="quote__text" data-bind="text: testimonials[{{ i }}].quote"></blockquote>
+            <blockquote class="quote__text" data-bind="text: testimonials[{{ i }}].quote">Cytat</blockquote>
             <figcaption class="quote__meta">
-              <span class="quote__author" data-bind="text: testimonials[{{ i }}].author"></span>
-              <span class="quote__role" data-bind="text: testimonials[{{ i }}].role"></span>
+              <span class="quote__author" data-bind="text: testimonials[{{ i }}].author">Jan Kowalski</span>
+              <span class="quote__role" data-bind="text: testimonials[{{ i }}].role">Stanowisko</span>
             </figcaption>
           </figure>
         {% endfor %}
@@ -375,7 +375,7 @@
         {% endfor %}
       {% else %}
         {% for i in range(0,8) %}
-          <li role="listitem"><img loading="lazy" decoding="async" data-bind="attr: { src: partners[{{ i }}].src, alt: partners[{{ i }}].alt }"></li>
+          <li role="listitem"><img loading="lazy" decoding="async" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Partner" data-bind="attr: { src: partners[{{ i }}].src, alt: partners[{{ i }}].alt }"></li>
         {% endfor %}
       {% endif %}
     </ul>
@@ -403,8 +403,8 @@
       {% else %}
         {% for i in range(0,6) %}
           <article class="card card--fleet" role="listitem">
-            <h3 class="card__title" data-bind="text: fleet[{{ i }}].title"></h3>
-            <p class="card__desc" data-bind="text: fleet[{{ i }}].desc"></p>
+            <h3 class="card__title" data-bind="text: fleet[{{ i }}].title">Tytuł pojazdu</h3>
+            <p class="card__desc" data-bind="text: fleet[{{ i }}].desc">Opis pojazdu</p>
           </article>
         {% endfor %}
       {% endif %}
@@ -435,9 +435,9 @@
       {% else %}
         {% for i in range(0,4) %}
           <article class="card card--pricing" role="listitem">
-            <h3 class="card__title" data-bind="text: pricing[{{ i }}].title"></h3>
-            <p class="card__desc" data-bind="text: pricing[{{ i }}].desc"></p>
-            <a class="card__link" data-bind="href: pricing[{{ i }}].slugKey|slug, text: pricing[{{ i }}].cta.label"></a>
+            <h3 class="card__title" data-bind="text: pricing[{{ i }}].title">Tytuł cennika</h3>
+            <p class="card__desc" data-bind="text: pricing[{{ i }}].desc">Opis cennika</p>
+            <a class="card__link" data-bind="href: pricing[{{ i }}].slugKey|slug, text: pricing[{{ i }}].cta.label">Sprawdź cennik</a>
           </article>
         {% endfor %}
       {% endif %}
@@ -467,9 +467,9 @@
       {% else %}
         {% for i in range(0,6) %}
           <article class="card card--post" role="listitem">
-            <h3 class="card__title" data-bind="text: blog[{{ i }}].title"></h3>
-            <p class="card__desc" data-bind="text: blog[{{ i }}].lead"></p>
-            <a class="card__link" data-bind="href: blog[{{ i }}].canonical_path, text: blog[{{ i }}].cta.label"></a>
+            <h3 class="card__title" data-bind="text: blog[{{ i }}].title">Tytuł wpisu</h3>
+            <p class="card__desc" data-bind="text: blog[{{ i }}].lead">Zajawka wpisu</p>
+            <a class="card__link" data-bind="href: blog[{{ i }}].canonical_path, text: blog[{{ i }}].cta.label">Czytaj więcej</a>
           </article>
         {% endfor %}
       {% endif %}
@@ -498,8 +498,8 @@
       {% else %}
         {% for i in range(0,12) %}
           <details class="qa" role="listitem">
-            <summary data-bind="text: faq[{{ i }}].q"></summary>
-            <div class="a"><p data-bind="text: faq[{{ i }}].a"></p></div>
+            <summary data-bind="text: faq[{{ i }}].q">Pytanie</summary>
+            <div class="a"><p data-bind="text: faq[{{ i }}].a">Odpowiedź</p></div>
           </details>
         {% endfor %}
       {% endif %}
@@ -519,12 +519,12 @@
       <a class="btn btn-primary"
          href="{{ href_by_slugkey('quote') }}"
          data-bind="href: final.cta_primary.slugKey|slug, text: final.cta_primary.label">
-        {{ ssr.final.cta_primary.label if ssr and ssr.final and ssr.final.cta_primary else '' }}
+        {{ ssr.final.cta_primary.label if ssr and ssr.final and ssr.final.cta_primary else 'Poznaj ofertę' }}
       </a>
       <a class="btn btn-ghost"
          href="{{ href_by_slugkey('contact') }}"
          data-bind="href: final.cta_secondary.slugKey|slug, text: final.cta_secondary.label">
-        {{ ssr.final.cta_secondary.label if ssr and ssr.final and ssr.final.cta_secondary else '' }}
+        {{ ssr.final.cta_secondary.label if ssr and ssr.final and ssr.final.cta_secondary else 'Skontaktuj się' }}
       </a>
     </div>
   </div>
@@ -533,7 +533,7 @@
 {# ================================================================
    Dodatkowe UI: przełącznik motywu (light/dark) — bez tekstów
    ================================================================ #}
-<button class="theme-toggle" type="button" data-action="theme-toggle" aria-label="" data-bind="attr:{'aria-label': home.theme_toggle_aria}">
+<button class="theme-toggle" type="button" data-action="theme-toggle" aria-label="Zmień motyw" data-bind="attr:{'aria-label': home.theme_toggle_aria}">
   <svg width="24" height="24" aria-hidden="true" class="sun"><circle cx="12" cy="12" r="5"/></svg>
   <svg width="24" height="24" aria-hidden="true" class="moon"><path d="M13 2a9 9 0 1 0 9 9A7 7 0 0 1 13 2z"/></svg>
 </button>

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -2,7 +2,7 @@
 {% block content %}
 <main>
 {% for post in posts %}
-  <a href="/{{lang}}/blog/{{ post.slug }}/">{{ post.h1 or post.title }}</a>
+  <a href="/{{lang}}/blog/{{ post.slug }}/">{{ post.h1 or post.title or 'Tytuł artykułu' }}</a>
 {% endfor %}
 </main>
 {% endblock %}

--- a/templates/pages/blog_post.html
+++ b/templates/pages/blog_post.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <article class="wrap" aria-busy="false">
-  <h1 class="post__title">{{ pg.h1 or pg.title or title }}</h1>
+  <h1 class="post__title">{{ pg.h1 or pg.title or title or 'Tytuł artykułu' }}</h1>
   {% if pg.lead %}<p class="lead">{{ pg.lead }}</p>{% endif %}
   {% if pg.date %}<p class="post__meta"><time datetime="{{ pg.date }}">{{ pg.date }}</time></p>{% endif %}
   {% if page_html %}<div class="content">{{ page_html|safe }}</div>

--- a/templates/pages/generic.html
+++ b/templates/pages/generic.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <main class="wrap" aria-busy="false">
-  <h1 class="page__title">{{ pg.h1 or pg.title or title }}</h1>
+  <h1 class="page__title">{{ pg.h1 or pg.title or title or 'Tytuł strony' }}</h1>
   {% if pg.lead %}<p class="lead">{{ pg.lead }}</p>{% endif %}
   {% if page_html %}<article class="content">{{ page_html|safe }}</article>
   {% elif pg.body_md %}<article class="content">{{ pg.body_md }}</article>{% endif %}


### PR DESCRIPTION
## Summary
- Ensure page template renders default text for data-bound elements so content remains visible without JavaScript
- Add generic fallbacks in page-specific templates to prevent empty titles

## Testing
- `python -u tools/build.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae9b711188333829deb7cc92c7de8