### PR TITLE
Ensure STR translations available in templates and tests build site

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -68,12 +68,12 @@
         <a class="btn btn-primary"
            href="{{ href_by_slugkey('quote') }}"
            data-bind="href: hero.cta_primary.slugKey|slug, text: hero.cta_primary.label">
-          {{ H.cta_primary.label if ssr else 'Poznaj ofertę' }}
+          {{ H.cta_primary.label if ssr else STR('cta_quote_primary') }}
         </a>
         <a class="btn btn-ghost"
            href="{{ href_by_slugkey('contact') }}"
            data-bind="href: hero.cta_secondary.slugKey|slug, text: hero.cta_secondary.label">
-           {{ H.cta_secondary.label if ssr else 'Skontaktuj się' }}
+           {{ H.cta_secondary.label if ssr else STR('cta_quote_secondary') }}
         </a>
         {% if company and company[0] and company[0].telephone %}
           <a class="btn btn-ghost"
@@ -519,12 +519,12 @@
       <a class="btn btn-primary"
          href="{{ href_by_slugkey('quote') }}"
          data-bind="href: final.cta_primary.slugKey|slug, text: final.cta_primary.label">
-        {{ ssr.final.cta_primary.label if ssr and ssr.final and ssr.final.cta_primary else 'Poznaj ofertę' }}
+        {{ ssr.final.cta_primary.label if ssr and ssr.final and ssr.final.cta_primary else STR('cta_quote_primary') }}
       </a>
       <a class="btn btn-ghost"
          href="{{ href_by_slugkey('contact') }}"
          data-bind="href: final.cta_secondary.slugKey|slug, text: final.cta_secondary.label">
-        {{ ssr.final.cta_secondary.label if ssr and ssr.final and ssr.final.cta_secondary else 'Skontaktuj się' }}
+        {{ ssr.final.cta_secondary.label if ssr and ssr.final and ssr.final.cta_secondary else STR('cta_quote_secondary') }}
       </a>
     </div>
   </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import subprocess, sys
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def build_site():
+    subprocess.run([sys.executable, 'tools/build.py'], check=True)

--- a/tools/build.py
+++ b/tools/build.py
@@ -1203,6 +1203,7 @@ def build_all():
 
             page_key = key
             meta = page_rec.get("meta") or {}
+            strings_local = {k: (v.get(L) or v.get(dlang) or "") for k, v in strings_map.items()}
             ctx = {
                 "lang": L,
                 "site": SITE,
@@ -1218,6 +1219,8 @@ def build_all():
                 "blocks": (blocks_by_page_lang.get((L, page_key)) if isinstance(blocks_by_page_lang, dict) else {}),
                 "faq": (faq_by_page_lang.get((L, page_key)) if isinstance(faq_by_page_lang, dict) else []),
                 "canonical": canonical,
+                "STR": lambda key, _L=L: STR(_L, key),
+                "strings": strings_local,
             }
             if (page_rec.get("slugKey") or "").lower() == "blog" or (page_rec.get("type") or "").lower() == "blog":
                 ctx["blog_posts"] = posts_by_lang.get(L, [])


### PR DESCRIPTION
## Summary
- Pass per-language STR helper and strings map to Jinja templates
- Use STR fallbacks for hero and final call-to-action labels
- Build site once before tests to generate dist output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab060132f083338af6eedab97e1619