### PR TITLE
Handle case-insensitive protocols

### DIFF
--- a/tests/test_sanitize_href.py
+++ b/tests/test_sanitize_href.py
@@ -22,3 +22,7 @@ def test_internal_with_query_no_trailing_slash():
 
 def test_internal_with_anchor_no_trailing_slash():
     assert _sanitize_href('/foo#bar', 'pl', 'Foo') == '/foo/#bar'
+
+
+def test_external_uppercase_protocol():
+    assert _sanitize_href('HTTPS://example.com', 'pl', 'Foo') == 'HTTPS://example.com'

--- a/tools/menu_builder.py
+++ b/tools/menu_builder.py
@@ -38,9 +38,8 @@ def _sanitize_href(href: Any, lang: str, label: str) -> str:
     h = str(href or "").strip()
     if not h:
         return f"/{lang}/{_slugify(label)}/"
-    # allowlist protocols
-    ok = h.startswith(SAFE_PROTOCOLS)
-    if not ok:
+    # allowlist protocols (case-insensitive)
+    if not h.lower().startswith(SAFE_PROTOCOLS):
         return f"/{lang}/{_slugify(label)}/"
 
     if h.startswith("/"):


### PR DESCRIPTION
## Summary
- Allow `_sanitize_href` to recognize protocols regardless of case
- Cover uppercase scheme scenario with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab075580008333a7a374e0f74a5615