### PR TITLE
Add hero lead identifiers

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -62,7 +62,7 @@
     <div class="hero__copy">
       <p class="hero__claim" data-bind="text: hero.claim">{{ H.claim if ssr and H.claim else pg.lead or STR('hero_claim') }}</p>
       <h1 id="hero-title" class="hero__title">{{ (H.title if ssr else (pg.h1 or pg.title)) or title }}</h1>
-      <p class="hero__lead">{{ H.lead if ssr and H.lead else pg.lead or meta_desc or STR('hero_lead') }}</p>
+      <p id="hero-lead" class="hero__lead">{{ H.lead if ssr and H.lead else pg.lead or meta_desc or STR('hero_lead') }}</p>
 
       <div class="cta-row">
         <a class="btn btn-primary"

--- a/templates/pages/generic.html
+++ b/templates/pages/generic.html
@@ -2,7 +2,7 @@
 {% block content %}
 <main class="wrap" aria-busy="false">
   <h1 class="page__title">{{ pg.h1 or pg.title or title or 'Tytuł strony' }}</h1>
-  {% if pg.lead %}<p class="lead">{{ pg.lead }}</p>{% endif %}
+  {% if pg.lead %}<p id="hero-lead" class="lead">{{ pg.lead }}</p>{% endif %}
   {% if page_html %}<article class="content">{{ page_html|safe }}</article>
   {% elif pg.body_md %}<article class="content">{{ pg.body_md }}</article>{% endif %}
 </main>


### PR DESCRIPTION
## Summary
- add `hero-lead` id to hero lead paragraphs in home and generic templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab65c9efec83339055542106b7ec57