### PR TITLE
Render hero lead solely from CMS

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -62,7 +62,7 @@
     <div class="hero__copy">
       <p class="hero__claim" data-bind="text: hero.claim">{{ H.claim if ssr and H.claim else pg.lead or STR('hero_claim') }}</p>
       <h1 id="hero-title" class="hero__title">{{ (H.title if ssr else (pg.h1 or pg.title)) or title }}</h1>
-      <p id="hero-lead" class="hero__lead">{{ H.lead if ssr and H.lead else pg.lead or meta_desc or STR('hero_lead') }}</p>
+      <p id="hero-lead" class="hero__lead">{{ pg.lead }}</p>
 
       <div class="cta-row">
         <a class="btn btn-primary"


### PR DESCRIPTION
## Summary
- Always use `pg.lead` for the hero lead, removing meta/SSR fallbacks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab751af2188333afcdd2ce4c155c80