### PR TITLE
Fetch CMS spreadsheet from CMS_SOURCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ CMS data and writes the generated site to the `dist/` directory.
 Menu labels must be unique within each language. During the build process,
 duplicate labels trigger a warning and the later entries are ignored.
 
-If the GitHub Actions runner cannot find a CMS Excel file, the workflow now
-creates an empty placeholder at `data/cms/menu.xlsx` and continues. This allows
-builds and tests to run without a private CMS source, though generated content
-will be minimal.
+If `data/cms/menu.xlsx` is missing, the build script tries to fetch the sheet
+from the location specified by the `CMS_SOURCE` environment variable. The value
+may point to a local file path or an HTTP(S) URL. The downloaded file is cached
+under `data/cms/menu.xlsx` for subsequent runs.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,18 @@
-import subprocess, sys
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 @pytest.fixture(scope="session", autouse=True)
-def build_site():
-    subprocess.run([sys.executable, 'tools/build.py'], check=True)
+def build_site(tmp_path_factory):
+    """Build the site using CMS data fetched via ``CMS_SOURCE``."""
+    src = Path("data/cms/menu.xlsx")
+    tmp_src = tmp_path_factory.mktemp("cms") / "menu.xlsx"
+    if src.exists():
+        shutil.copy2(src, tmp_src)
+        src.unlink()
+    os.environ["CMS_SOURCE"] = str(tmp_src)
+    subprocess.run([sys.executable, "tools/build.py"], check=True)

--- a/tools/build.py
+++ b/tools/build.py
@@ -1041,11 +1041,10 @@ def build_all():
         except Exception as e:
             print(f"[nav.yml] read error: {e}", file=sys.stderr)
     nav_by_lang = nav_fallback
-    # === CMS: wczytaj XLSX z runnera (LOCAL_XLSX/CMS_SOURCE albo stała ścieżka) ===
-    src_path = os.getenv("LOCAL_XLSX") or os.getenv("CMS_SOURCE") or "/Users/illia/Desktop/Kras_transStrona/CMS.xlsx"
+    # === CMS: wczytaj XLSX z katalogu DATA/cms (pobierany automatycznie) ===
     cms = {"menu_rows": [], "page_meta": {}, "blocks": {}, "report": "[cms] no module"}
     if cms_ingest:
-        cms = cms_ingest.load_all((DATA / "cms"), explicit_src=Path(src_path))
+        cms = cms_ingest.load_all(DATA / "cms")
         print(cms.get("report", "[cms] no report"))
     else:
         print("[cms] cms_ingest not available")


### PR DESCRIPTION
## Summary
- load cms spreadsheet using `cms_ingest.load_all(DATA / "cms")`
- allow `cms_ingest.load_all` to download spreadsheet from `CMS_SOURCE` when cache missing
- document and test fetching CMS data via `CMS_SOURCE`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab77074a0c8333a3aab7ca2cdbeba6