### PR TITLE
Apply persisted theme early

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ from the location specified by the `CMS_SOURCE` environment variable. The value
 may point to a local file path or an HTTP(S) URL. The downloaded file is cached
 under `data/cms/menu.xlsx` for subsequent runs.
 
+## Theme handling
+
+The base template includes a tiny inline script that reads the saved theme from
+`localStorage` and toggles `theme-dark` before CSS loads. This prevents a flash
+of the wrong theme on initial page render. The same logic powers the theme
+switcher in `templates/_partials/header.html`.
+

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -350,11 +350,10 @@
     dockMenu.addEventListener('click', e=>{ e.preventDefault(); openDrawer(); });
 
     /* THEME */
-    const THEME_KEY='kt_theme';
+    const THEME_KEY = window.THEME_KEY || 'kt_theme';
     function applyTheme(){
       const saved = localStorage.getItem(THEME_KEY) || 'auto';
-      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const effectiveDark = saved==='dark' || (saved==='auto' && prefersDark);
+      const effectiveDark = window.themeIsDark();
       document.documentElement.classList.toggle('theme-dark', effectiveDark);
       themeIcon.src = effectiveDark ? SUN : MOON;
       themeLabel.textContent = saved[0].toUpperCase()+saved.slice(1);

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,6 +99,19 @@
           {% if page.lcp_image.srcset %}imagesrcset="{{ page.lcp_image.srcset }}"{% endif %} />
   {% endif %}
 
+  {# --- Early theme (avoid flash of wrong theme before CSS) --- #}
+  <script>
+    (function () {
+      window.THEME_KEY = 'kt_theme';
+      window.themeIsDark = function () {
+        const saved = localStorage.getItem(window.THEME_KEY) || 'auto';
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        return saved === 'dark' || (saved === 'auto' && prefersDark);
+      };
+      document.documentElement.classList.toggle('theme-dark', window.themeIsDark());
+    })();
+  </script>
+
   {# --- Preloady / CSS (z pages.yml / buildera) --- #}
   {% if assets.preload %}
     {% for p in assets.preload %}


### PR DESCRIPTION
## Summary
- set `theme-dark` class before CSS loads using inline script
- reuse `themeIsDark` in theme switcher for consistent rendering
- document early theme application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab8218b8048333bdac559168f06480