### PR TITLE
Handle dropdown escape key and focus reset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ beautifulsoup4>=4.12
 lxml>=4.9
 python-slugify>=8.0
 Pillow>=10.3   # opcjonalnie – jeśli włączymy pipeline obrazów (AVIF/WebP)
+playwright>=1.42

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -372,6 +372,19 @@
     });
     document.addEventListener('click', e=>{ if(!themeDd.contains(e.target) && e.target!==themeBtn) { themeDd.setAttribute('aria-hidden','true'); themeBtn.setAttribute('aria-expanded','false'); }});
 
+    document.addEventListener('keydown', e=>{
+      if(e.key==='Escape'){
+        if(langBtn.getAttribute('aria-expanded')==='true'){
+          openLangs(false); langBtn.focus();
+        }
+        if(themeBtn.getAttribute('aria-expanded')==='true'){
+          themeDd.setAttribute('aria-hidden','true');
+          themeBtn.setAttribute('aria-expanded','false');
+          themeBtn.focus();
+        }
+      }
+    });
+
     /* LANGS dropdown */
     function openLangs(open){ langBtn.setAttribute('aria-expanded', String(open)); langDd.setAttribute('aria-hidden', String(!open)); }
     langBtn.addEventListener('click', ()=>{ const exp=langBtn.getAttribute('aria-expanded')==='true'; openLangs(!exp); });

--- a/tests/test_dropdown_keyboard.py
+++ b/tests/test_dropdown_keyboard.py
@@ -1,0 +1,36 @@
+from playwright.sync_api import sync_playwright
+
+
+def test_dropdown_keyboard_navigation():
+    html = """
+    <!DOCTYPE html>
+    <button id='langBtn' aria-expanded='false'>Lang</button>
+    <div id='langsDd' aria-hidden='true'>
+      <a href='#'>PL</a>
+      <a href='#'>EN</a>
+    </div>
+    <script>
+    const langBtn = document.getElementById('langBtn');
+    const langDd = document.getElementById('langsDd');
+    function openLangs(open){ langBtn.setAttribute('aria-expanded', String(open)); langDd.setAttribute('aria-hidden', String(!open)); }
+    langBtn.addEventListener('click', ()=>{ const exp=langBtn.getAttribute('aria-expanded')==='true'; openLangs(!exp); });
+    document.addEventListener('keydown', e=>{
+      if(e.key==='Escape' && langBtn.getAttribute('aria-expanded')==='true'){
+        openLangs(false); langBtn.focus();
+      }
+    });
+    </script>
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.set_content(html)
+        page.focus('#langBtn')
+        page.keyboard.press('Enter')
+        assert page.get_attribute('#langBtn', 'aria-expanded') == 'true'
+        assert page.get_attribute('#langsDd', 'aria-hidden') == 'false'
+        page.keyboard.press('Escape')
+        assert page.get_attribute('#langBtn', 'aria-expanded') == 'false'
+        assert page.get_attribute('#langsDd', 'aria-hidden') == 'true'
+        assert page.evaluate('document.activeElement.id') == 'langBtn'
+        browser.close()


### PR DESCRIPTION
## Summary
- Close language and theme dropdowns when Escape is pressed
- Return focus to the dropdown trigger after closing
- Add Playwright integration test for keyboard navigation

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...; run `playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab83c827808333aee6cd28b7429f0b