### PR TITLE
Refine header layout and typography

### DIFF
--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -13,7 +13,7 @@
   <!-- ============== CRITICAL CSS (scoped do #site-header) ============== -->
   <style>
     #site-header{--bg:rgba(255,255,255,.82);--ink:#0b1020;--ink-weak:#64748b;--line:rgba(0,0,0,.08);
-      --brand:#0ea5e9;--ease:cubic-bezier(.2,.7,.2,1);--mega-h:0px}
+      --brand:#0ea5e9;--ease:cubic-bezier(.2,.7,.2,1);--mega-h:0px;--fs-header:clamp(.75rem,2.2vw,1rem)}
     @media (prefers-color-scheme:dark){
       #site-header{--bg:rgba(15,23,42,.62);--ink:#e5e7eb;--ink-weak:#94a3b8;--line:rgba(255,255,255,.10)}
     }
@@ -24,22 +24,22 @@
     #site-header .wrap{max-width:980px;margin:0 auto;padding:0 12px 0 8px}
     @media (min-width:768px){ #site-header .wrap{padding:0 18px 0 12px} }
 
-    .bar{display:grid;grid-template-columns:minmax(120px,170px) 1fr auto;gap:10px;align-items:center;padding:6px 0}
+    .bar{display:grid;grid-template-columns:minmax(120px,170px) 1fr auto;gap:10px;justify-items:center;align-items:center;padding:6px 0}
     #site-header a{color:inherit;text-decoration:none}
-    .brand{display:inline-flex;align-items:center;gap:10px;margin-left:-4px}
-    .brand__logo{height:auto;max-width:160px;width:clamp(110px,10vw,160px);transition:transform .18s ease,filter .18s ease}
+    .brand{display:inline-flex;align-items:center;gap:10px}
+    .brand__logo{height:auto;width:clamp(90px,24vw,160px);transition:transform .18s ease,filter .18s ease}
     .brand:hover .brand__logo{transform:scale(1.045);filter:drop-shadow(0 6px 18px rgba(14,165,233,.28))}
 
     .nav__list{list-style:none;margin:0;padding:0;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
     .nav__list>li{position:relative}
     .nav__list>li>a,.nav__list>li>button{appearance:none;background:transparent;border:0;color:inherit;font:inherit;line-height:1;cursor:pointer;
-      padding:8px 10px;border-radius:12px;display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+      padding:8px 10px;border-radius:12px;display:inline-flex;align-items:center;gap:6px;white-space:nowrap;font-size:var(--fs-header)}
     .nav__list>li:hover>a{background:rgba(0,0,0,.04)}
     @media (prefers-color-scheme:dark){ .nav__list>li:hover>a{background:rgba(255,255,255,.06)}}
 
     .actions{display:flex;align-items:center;gap:10px}
     .btn{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:14px;border:1px solid var(--line);
-      background:#fff;font-weight:700;color:var(--ink);transition:transform .15s ease, background .2s ease}
+      background:#fff;font-weight:700;font-size:var(--fs-header);color:var(--ink);transition:transform .15s ease, background .2s ease}
     .btn:hover{transform:translateY(-1px)}
     @media (prefers-color-scheme:dark){ .btn{background:rgba(255,255,255,.06)}}
     .btn-primary{background:var(--brand);border-color:transparent;color:#fff}
@@ -71,14 +71,14 @@
     .social{display:flex;gap:8px;margin-left:6px}
     .social a{display:inline-flex;padding:8px;border-radius:50%}
     .status-pill{margin-left:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--line);
-      font-weight:600;color:var(--ink-weak);background:rgba(14,165,233,.08)}
+      font-weight:600;font-size:var(--fs-header);color:var(--ink-weak);background:rgba(14,165,233,.08)}
 
     @media (max-width:600px){
       .bar{grid-template-columns:auto 1fr}
       .bar>*{min-width:0}
       .actions{flex-wrap:wrap}
       .actions>*{flex:1 1 auto;min-width:0}
-      .btn{max-width:100%;box-sizing:border-box;padding:6px 8px;font-size:clamp(.8rem,2.5vw,1rem)}
+      .btn{max-width:100%;box-sizing:border-box;padding:6px 8px;font-size:var(--fs-header)}
       .social,.status-pill{display:none}
     }
 


### PR DESCRIPTION
## Summary
- center header grid items and remove leftover negative margin
- add `--fs-header` variable for consistent header font sizing
- tweak logo scaling with `clamp` for smoother responsiveness

## Testing
- `pytest` *(fails: BrowserType.launch executable missing; playwright install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abb3acc3d8833394051b67ec513f83