### PR TITLE
Ensure mobile menu fits within viewport

### DIFF
--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -110,7 +110,7 @@
 
     .mobile-menu{position:fixed;inset:0;background:rgba(0,0,0,.4);backdrop-filter:blur(2px);z-index:80}
     .mobile-menu[hidden]{display:none}
-    .mobile-menu__inner{position:absolute;top:0;right:0;bottom:0;width:min(420px,92vw);background:var(--bg);
+    .mobile-menu__inner{position:absolute;top:0;right:0;bottom:0;box-sizing:border-box;width:min(420px,100vw);background:var(--bg);
       border-left:1px solid var(--line);transform:translateX(100%);transition:transform .28s var(--ease);
       display:grid;grid-template-rows:auto 1fr auto auto;gap:12px;padding:16px}
     .mobile-menu[data-open="true"] .mobile-menu__inner{transform:translateX(0)}


### PR DESCRIPTION
## Summary
- prevent mobile menu from exceeding viewport by using border-box sizing and min(420px,100vw)

## Testing
- `pip install -r requirements.txt`
- `playwright install chromium` *(fails: Domain forbidden)*
- `pytest` *(fails: BrowserType.launch TargetClosedError)*
- `python - <<'PY' ...` *(fails: BrowserType.launch TargetClosedError)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe5206a08333a46b21c21e836892