### PR TITLE
Ensure mega menu re-binds after navigation updates

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -41,10 +41,12 @@
       }).join('');
   }
 
+  let docBound = false;
+  function closeAll(except){ $$('.mega-toggle').forEach(b=>{ if(b!==except) b.setAttribute('aria-expanded','false'); }); }
   function bindMega(){
-    const btns = $$('.mega-toggle');
-    function closeAll(except){ btns.forEach(b=>{ if(b!==except) b.setAttribute('aria-expanded','false'); }); }
-    btns.forEach(btn=>{
+    $$('.mega-toggle').forEach(btn=>{
+      if(btn.dataset.megaBound) return;
+      btn.dataset.megaBound='1';
       const panel = document.getElementById(btn.getAttribute('aria-controls'));
       const set = v=>btn.setAttribute('aria-expanded', v?'true':'false');
       btn.addEventListener('click', e=>{
@@ -54,8 +56,11 @@
       });
       if (panel) panel.addEventListener('mouseleave', ()=>set(false));
     });
-    document.addEventListener('click', ()=>closeAll(null));
-    document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(null); });
+    if(!docBound){
+      document.addEventListener('click', ()=>closeAll(null));
+      document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(null); });
+      docBound = true;
+    }
   }
 
   function currentVersion(){
@@ -92,7 +97,16 @@
     }catch(e){ console.warn('[cms] navigation update failed', e); }
   }
 
+  function watchNav(){
+    const ul = document.getElementById(UL_ID);
+    if(!ul) return;
+    const mo = new MutationObserver(()=>bindMega());
+    mo.observe(ul, {childList:true, subtree:true});
+  }
+
   function start(){
+    bindMega();
+    watchNav();
     if ('requestIdleCallback' in window) requestIdleCallback(revalidate);
     else setTimeout(revalidate, 600);
     setInterval(revalidate, 5*60*1000);

--- a/tests/test_bind_mega.py
+++ b/tests/test_bind_mega.py
@@ -1,0 +1,28 @@
+from playwright.sync_api import sync_playwright
+
+
+def test_bind_mega_initial_and_dynamic():
+    html = """
+    <!DOCTYPE html>
+    <ul id='navList'>
+      <li class='has-mega'>
+        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-a'>A</button>
+        <div id='mega-a'></div>
+      </li>
+    </ul>
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.set_content(html)
+        page.add_script_tag(path='assets/js/cms.js')
+        page.click("button[aria-controls='mega-a']")
+        assert page.get_attribute("button[aria-controls='mega-a']", 'aria-expanded') == 'true'
+        page.evaluate("""
+        document.getElementById('navList').innerHTML += `\n      <li class='has-mega'>\n        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-b'>B</button>\n        <div id='mega-b'></div>\n      </li>`
+        """)
+        page.wait_for_selector("button[aria-controls='mega-b']")
+        page.wait_for_function("document.querySelector(\"button[aria-controls='mega-b']\").dataset.megaBound === '1'")
+        page.click("button[aria-controls='mega-b']")
+        assert page.get_attribute("button[aria-controls='mega-b']", 'aria-expanded') == 'true'
+        browser.close()


### PR DESCRIPTION
## Summary
- call `bindMega` on start and whenever `#navList` changes to keep mega menu bindings current
- safeguard against duplicate listeners and track bindings with `data-mega-bound`
- add Playwright test exercising binding on initial and dynamic navigation

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abbf6526cc8333a09f1841d8c199f9