### PR TITLE
Use cms.js for mega-menu and implement accessibility toggles

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -31,7 +31,7 @@
           }).join('');
           return `<li class="has-mega">
             <button class="mega-toggle" aria-expanded="false" aria-controls="${id}">${label}</button>
-            <div id="${id}" class="mega" role="dialog" aria-label="${label}" aria-modal="false">
+            <div id="${id}" class="mega" role="dialog" aria-label="${label}" aria-modal="false" hidden aria-hidden="true">
               <div class="mega-grid">${colsHTML}</div>
             </div>
           </li>`;
@@ -42,13 +42,24 @@
   }
 
   let docBound = false;
-  function closeAll(except){ $$('.mega-toggle').forEach(b=>{ if(b!==except) b.setAttribute('aria-expanded','false'); }); }
+  function closeAll(except){
+    $$('.mega-toggle').forEach(b=>{
+      if(except && b===except) return;
+      b.setAttribute('aria-expanded','false');
+      const p = document.getElementById(b.getAttribute('aria-controls'));
+      if(p){ p.hidden=true; p.setAttribute('aria-hidden','true'); }
+    });
+  }
   function bindMega(){
     $$('.mega-toggle').forEach(btn=>{
       if(btn.dataset.megaBound) return;
       btn.dataset.megaBound='1';
       const panel = document.getElementById(btn.getAttribute('aria-controls'));
-      const set = v=>btn.setAttribute('aria-expanded', v?'true':'false');
+      if(panel){ panel.hidden=true; panel.setAttribute('aria-hidden','true'); }
+      const set = v=>{
+        btn.setAttribute('aria-expanded', v?'true':'false');
+        if(panel){ panel.hidden=!v; panel.setAttribute('aria-hidden', v?'false':'true'); }
+      };
       btn.addEventListener('click', e=>{
         e.stopPropagation();
         const open = btn.getAttribute('aria-expanded') !== 'true';
@@ -57,8 +68,8 @@
       if (panel) panel.addEventListener('mouseleave', ()=>set(false));
     });
     if(!docBound){
-      document.addEventListener('click', ()=>closeAll(null));
-      document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(null); });
+      document.addEventListener('click', ()=>closeAll());
+      document.addEventListener('keydown', e=>{ if(e.key==='Escape') closeAll(); });
       docBound = true;
     }
   }

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -1,3 +1,2 @@
 <meta name="menu-bundle-version" content="{{ menu_version }}">
-<script defer src="/assets/js/menu.js"></script>
 

--- a/tests/test_bind_mega.py
+++ b/tests/test_bind_mega.py
@@ -7,7 +7,7 @@ def test_bind_mega_initial_and_dynamic():
     <ul id='navList'>
       <li class='has-mega'>
         <button class='mega-toggle' aria-expanded='false' aria-controls='mega-a'>A</button>
-        <div id='mega-a'></div>
+        <div id='mega-a' hidden aria-hidden='true'></div>
       </li>
     </ul>
     """
@@ -18,11 +18,18 @@ def test_bind_mega_initial_and_dynamic():
         page.add_script_tag(path='assets/js/cms.js')
         page.click("button[aria-controls='mega-a']")
         assert page.get_attribute("button[aria-controls='mega-a']", 'aria-expanded') == 'true'
+        assert page.get_attribute("#mega-a", 'hidden') is None
+        assert page.get_attribute("#mega-a", 'aria-hidden') == 'false'
         page.evaluate("""
-        document.getElementById('navList').innerHTML += `\n      <li class='has-mega'>\n        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-b'>B</button>\n        <div id='mega-b'></div>\n      </li>`
+        document.getElementById('navList').innerHTML += `\n      <li class='has-mega'>\n        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-b'>B</button>\n        <div id='mega-b' hidden aria-hidden='true'></div>\n      </li>`
         """)
         page.wait_for_selector("button[aria-controls='mega-b']")
         page.wait_for_function("document.querySelector(\"button[aria-controls='mega-b']\").dataset.megaBound === '1'")
         page.click("button[aria-controls='mega-b']")
         assert page.get_attribute("button[aria-controls='mega-b']", 'aria-expanded') == 'true'
+        assert page.get_attribute("#mega-b", 'hidden') is None
+        assert page.get_attribute("#mega-b", 'aria-hidden') == 'false'
+        assert page.get_attribute("button[aria-controls='mega-a']", 'aria-expanded') == 'false'
+        assert page.get_attribute("#mega-a", 'hidden') == ''
+        assert page.get_attribute("#mega-a", 'aria-hidden') == 'true'
         browser.close()


### PR DESCRIPTION
## Summary
- remove menu.js from templates and rely on cms.js for mega menu
- add hidden/aria-hidden/aria-expanded handling in cms.js
- extend mega menu test to cover panel visibility

## Testing
- `python -m pip install -r requirements.txt`
- `playwright install chromium` *(fails: Domain forbidden)*
- `pytest tests/test_bind_mega.py::test_bind_mega_initial_and_dynamic -q` *(hangs: missing browser)*


------
https://chatgpt.com/codex/tasks/task_e_68abc129c0888333be546ef1451b889b