### PR TITLE
Ensure mega menu panels toggle aria-hidden

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -40,7 +40,7 @@
             const list = buildList(col.items||[]);
             return `<div class="mega-col">${title}${list}</div>`;
           }).join('');
-          return `<li class="has-mega"><button class="mega-toggle" aria-expanded="false" aria-controls="${id}">${label}</button><div id="${id}" class="mega" aria-hidden="true"><div class="mega-grid">${colsHTML}</div></div></li>`;
+          return `<li class="has-mega"><button class="mega-toggle" aria-expanded="false" aria-controls="${id}">${label}</button><div id="${id}" class="mega" aria-hidden="true" hidden><div class="mega-grid">${colsHTML}</div></div></li>`;
         }
         return `<li><a href="${href}">${label}</a></li>`;
       }).join('');
@@ -52,18 +52,22 @@
       btns.forEach(b=>{
         const p = document.getElementById(b.getAttribute('aria-controls'));
         b.setAttribute('aria-expanded','false');
-        if(p) p.hidden=true;
+        if(p){ p.hidden=true; p.setAttribute('aria-hidden','true'); }
       });
     }
     btns.forEach((btn,idx)=>{
       const panel = document.getElementById(btn.getAttribute('aria-controls'));
-      if(panel) panel.hidden=true;
+      if(panel){ panel.hidden=true; panel.setAttribute('aria-hidden','true'); }
       btn.addEventListener('click',e=>{
         const exp = btn.getAttribute('aria-expanded')==='true';
         closeAll();
         if(!exp){
           btn.setAttribute('aria-expanded','true');
-          if(panel){ panel.hidden=false; const first = panel.querySelector('a,button'); first&&first.focus(); }
+          if(panel){
+            panel.hidden=false;
+            panel.setAttribute('aria-hidden','false');
+            const first = panel.querySelector('a,button'); first&&first.focus();
+          }
         }
         e.stopPropagation();
       });

--- a/tests/test_menu_aria_hidden.py
+++ b/tests/test_menu_aria_hidden.py
@@ -1,0 +1,30 @@
+from playwright.sync_api import sync_playwright
+
+
+def test_menu_toggle_updates_visibility_and_a11y():
+    html = """
+    <!DOCTYPE html>
+    <ul id='navList'>
+      <li class='has-mega'>
+        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-a'>A</button>
+        <div id='mega-a' class='mega' hidden aria-hidden='true'><a href='#'>link</a></div>
+      </li>
+    </ul>
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.set_content(html)
+        page.add_script_tag(path='assets/js/menu.js')
+        # open
+        page.click("button[aria-controls='mega-a']")
+        assert page.get_attribute("button[aria-controls='mega-a']", 'aria-expanded') == 'true'
+        assert page.get_attribute("#mega-a", 'hidden') is None
+        assert page.get_attribute("#mega-a", 'aria-hidden') == 'false'
+        # close
+        page.click("button[aria-controls='mega-a']")
+        assert page.get_attribute("button[aria-controls='mega-a']", 'aria-expanded') == 'false'
+        assert page.get_attribute("#mega-a", 'hidden') == ''
+        assert page.get_attribute("#mega-a", 'aria-hidden') == 'true'
+        browser.close()
+


### PR DESCRIPTION
## Summary
- Add `hidden` and `aria-hidden` toggling logic to `menu.js` mega menu panels so visibility matches `aria-expanded`
- Add Playwright test covering `menu.js` accessibility behavior

## Testing
- `playwright install chromium` *(fails: Download failed: server returned code 403)*
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68abc621cb58833391c2bc9c7573145a