### PR TITLE
Hide header when scrolling down and reveal for menus

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -100,6 +100,7 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 #site-header.site-header.sq--shadow{box-shadow:0 8px 20px rgba(0,0,0,.06)}
 #site-header.site-header.is-sticky{box-shadow:0 8px 20px rgba(0,0,0,.06)}
 #site-header.site-header.is-shrunk .bar{padding-block:6px}
+.site-header.is-hidden{transform:translateY(-100%);transition:transform .25s var(--mega-ease)}
 #site-header .bar{
   display:grid; grid-template-columns:160px 1fr auto; align-items:center; gap:10px;
   padding-block:10px;

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -112,6 +112,7 @@
   function initHeaderSquarespace() {
     const header = $('#site-header.sq');
     if (!header) return;
+    let lastY = window.scrollY;
 
     const mega = $('#mega');
     const panelsWrap = mega ? $('.mega__panels', mega) : null;
@@ -156,8 +157,12 @@
     // sticky & shrink
     const onScroll = throttle(() => {
       const y = window.scrollY || document.documentElement.scrollTop || 0;
+      const dir = y - lastY;
       header.classList.toggle('is-sticky', y > 0);
       header.classList.toggle('is-shrunk', y > 80);
+      if (dir > 0 && y > 80) header.classList.add('is-hidden');
+      if (dir < 0) header.classList.remove('is-hidden');
+      lastY = y;
     }, 100);
     onScroll();
     window.addEventListener('scroll', onScroll, { passive:true });
@@ -195,6 +200,7 @@
       mega.dataset.state = 'open';
       mega.setAttribute('aria-hidden', 'false');
       header.dataset.mega = 'open';
+      header.classList.remove('is-hidden');
       currentId = id;
       const focusable = panel.querySelector('a,button,input,select,textarea');
       lastFocus = document.activeElement;
@@ -249,6 +255,7 @@
       requestAnimationFrame(() => drawer.setAttribute('data-open','true'));
       toggle.setAttribute('aria-expanded','true');
       document.body.classList.add('nav-open');
+      header.classList.remove('is-hidden');
     }
     function closeDrawer() {
       drawer.removeAttribute('data-open');


### PR DESCRIPTION
## Summary
- Hide Squarespace header when scrolling down and show when scrolling up
- Keep header visible when opening mega panel or mobile menu
- Add CSS for hidden header state

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist; Playwright dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3509789c833392a07ff417e4a0b5