### PR TITLE
Generate mega menu panels from CMS bundle

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -372,7 +372,7 @@
       });
     }
   }
-
+  window.initHeaderSquarespace = initHeaderSquarespace;
 
   document.addEventListener('DOMContentLoaded', () => {
     initProgress();


### PR DESCRIPTION
## Summary
- Build nav items with `data-panel` buttons and no inline mega panels
- Create `<section>` panels from CMS data and inject into `#mega .mega__panels`
- Expose and re-run `initHeaderSquarespace` after replacing navigation

## Testing
- `playwright install chromium` *(fails: Download failed with 403 Domain forbidden)*
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac411297fc83338f3e1d7bf29435cf