### PR TITLE
chore: install playwright deps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install --upgrade playwright
-          python -m playwright install chromium
+          python -m playwright install --with-deps chromium
 
       - name: Run tests
         if: ${{ hashFiles('tests/**') != '' }}


### PR DESCRIPTION
## Summary
- ensure GitHub workflow installs Playwright Chromium with system deps
- keep Playwright browser cache for faster CI

## Testing
- `pytest -q` *(fails: tests/test_bind_mega.py::test_bind_mega_initial_and_dynamic, tests/test_menu_aria_hidden.py::test_menu_toggle_updates_visibility_and_a11y)*
- `pytest tests/test_dropdown_keyboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4fd5fab88333bcfe42623cbc67fd