### PR TITLE
Ensure hero lead and CTA come from CMS

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -65,7 +65,7 @@
       <p id="hero-lead" class="hero__lead">{{ pg.lead }}</p>
 
       <div class="cta-row">
-        <a class="btn btn-primary"
+        <a id="cta" class="btn btn-primary"
            href="{{ href_by_slugkey('quote') }}"
            data-bind="href: hero.cta_primary.slugKey|slug, text: hero.cta_primary.label">
           {{ H.cta_primary.label if ssr else STR('cta_quote_primary') }}


### PR DESCRIPTION
## Summary
- map Pages rows to page fields via `_page_fields`
- populate SSR hero from CMS lead and CTA label
- mark primary hero CTA with `id="cta"`

## Testing
- `python tools/build.py`
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5741ecf08333b29a84dcfb501fe8