### PR TITLE
Refactor mega menu toggle to use separate button

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -345,7 +345,8 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 @media (min-width:900px){ .footer-grid{grid-template-columns:1.2fr 1fr 1fr 1fr} }
 /* === Mega menu (kolumny, bez migotania) === */
 .nav-list{display:flex;gap:14px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
-.has-mega{position:relative}
+.has-mega{position:relative;display:inline-flex;align-items:center}
+.has-mega>.mega-toggle{margin-left:-4px}
 .mega-toggle{background:none;border:0;padding:8px 10px;border-radius:8px;cursor:pointer}
 .mega{position:absolute;left:50%;transform:translateX(-50%);top:120%;width:100vw;max-width:1200px;background:#fff;border:1px solid #e5e7eb;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.08);padding:20px;display:none;z-index:1000}
 .mega-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:20px}

--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -144,10 +144,21 @@
     if (!root.__cmsMegaListener) {
       root.addEventListener('click', e => {
         const btn = e.target.closest && e.target.closest('.mega-toggle');
-        if (!btn) return;
-        toggleMega(btn, root);
+        if (btn) {
+          e.preventDefault();
+          toggleMega(btn, root);
+        } else if (!e.target.closest || !e.target.closest('.has-mega')) {
+          closeOthers(null, root);
+        }
       });
       root.__cmsMegaListener = true;
+    }
+
+    if (!root.__cmsMegaKeyListener) {
+      root.addEventListener('keydown', e => {
+        if (e.key === 'Escape') closeOthers(null, root);
+      });
+      root.__cmsMegaKeyListener = true;
     }
 
     if (root.querySelectorAll) {

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -1,0 +1,24 @@
+{% for item in (nav_data.primary or []) %}
+  {% if item.cols %}
+    {% set mid = 'm-' ~ loop.index %}
+    <li class="has-mega">
+      <a href="{{ item.href }}">{{ item.label }}</a>
+      <button class="mega-toggle" aria-expanded="false" aria-controls="mega-{{ mid }}">▾</button>
+      <div id="mega-{{ mid }}" class="mega" hidden aria-hidden="true">
+        <div class="mega-grid">
+          {% for col in item.cols %}
+            <div class="mega-col">
+              <ul>
+                {% for ch in col %}
+                  <li><a href="{{ ch.href }}">{{ ch.label }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </li>
+  {% else %}
+    <li><a href="{{ item.href }}">{{ item.label }}</a></li>
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- split mega-menu items into link, toggle button and panel container
- update mega-nav binding to close on outside click/escape and manage aria state
- tweak mega menu styles so chevron button doesn't cover link

## Testing
- `pytest tests/test_bind_mega.py tests/test_menu_aria_hidden.py` *(fails: BrowserType.launch: Executable doesn't exist)*
- `playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac62392aec83339ed346d0e6a6d295