### PR TITLE
Hide empty home sections

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -84,19 +84,12 @@
         {% endif %}
       </div>
 
-      <ul class="hero__kpi" role="list">
-        {# SSR KPI (opcjonalnie) #}
-        {% if ssr and H.kpi %}
-          {% for k in H.kpi %}
+        {% set kpi = H.kpi if ssr and H.kpi else [] %}
+        <ul class="hero__kpi" role="list"{% if not kpi %} hidden{% endif %}>
+          {% for k in kpi %}
             <li role="listitem"><strong data-counter="{{ k.value }}">{{ k.value }}</strong><span>{{ k.label }}</span></li>
           {% endfor %}
-        {% else %}
-          {# CSR: cztery puste sloty do wypełnienia #}
-          {% for i in range(0,4) %}
-            <li role="listitem"><strong data-bind="text: hero.kpi[{{ i }}].value">0</strong><span data-bind="text: hero.kpi[{{ i }}].label">KPI</span></li>
-          {% endfor %}
-        {% endif %}
-      </ul>
+        </ul>
     </div>
 
     <div class="hero__media">
@@ -200,29 +193,21 @@
 {# ================================================================
    2) INDUSTRIES — siatka 3/4 kolumny
    ================================================================ #}
+{% set industries = ssr.industries if ssr and ssr.industries else [] %}
 <section id="industries" class="section section--altB" aria-labelledby="ind-title"
-        data-api="/home/industries" aria-busy="false">
+        data-api="/home/industries" aria-busy="false"{% if not industries %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="ind-title">{{ ssr.home.section_titles.industries if ssr and ssr.home.section_titles.industries else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.industries if ssr and ssr.home.section_subtitles.industries else '' }}</p>
     </header>
     <div class="grid grid--auto" role="list">
-      {% if ssr and ssr.industries %}
-        {% for it in ssr.industries %}
-          <article class="tile3d" role="listitem">
-            <h3>{{ it.title }}</h3>
-            <p>{{ it.desc }}</p>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <article class="tile3d" role="listitem">
-            <h3 data-bind="text: industries[{{ i }}].title">Branża</h3>
-            <p data-bind="text: industries[{{ i }}].desc">Opis branży</p>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for it in industries %}
+        <article class="tile3d" role="listitem">
+          <h3>{{ it.title }}</h3>
+          <p>{{ it.desc }}</p>
+        </article>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -230,29 +215,21 @@
 {# ================================================================
    3) COVERAGE — korytarze, mini map-widget (dekor)
    ================================================================ #}
+{% set coverage = ssr.coverage if ssr and ssr.coverage else [] %}
 <section id="coverage" class="section section--altC" aria-labelledby="cov-title"
-        data-api="/home/coverage" aria-busy="false">
+        data-api="/home/coverage" aria-busy="false"{% if not coverage %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="cov-title">{{ ssr.home.section_titles.coverage if ssr and ssr.home.section_titles.coverage else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.coverage if ssr and ssr.home.section_subtitles.coverage else '' }}</p>
     </header>
     <div class="grid grid--auto" role="list">
-      {% if ssr and ssr.coverage %}
-        {% for it in ssr.coverage %}
-          <article class="card card--ghost" role="listitem">
-            <h3 class="card__title">{{ it.title }}</h3>
-            <p class="card__desc">{{ it.desc }}</p>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <article class="card card--ghost" role="listitem">
-            <h3 class="card__title" data-bind="text: coverage[{{ i }}].title">Region</h3>
-            <p class="card__desc" data-bind="text: coverage[{{ i }}].desc">Opis regionu</p>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for it in coverage %}
+        <article class="card card--ghost" role="listitem">
+          <h3 class="card__title">{{ it.title }}</h3>
+          <p class="card__desc">{{ it.desc }}</p>
+        </article>
+      {% endfor %}
     </div>
     <div class="map-decor" aria-hidden="true">
       <svg viewBox="0 0 800 120" preserveAspectRatio="none"><path d="M0,80 Q200,10 400,80 T800,80 L800,120 L0,120 Z" fill="currentColor" opacity=".06"/></svg>
@@ -263,26 +240,18 @@
 {# ================================================================
    4) PROCESS — timeline (ol > li)
    ================================================================ #}
+{% set process = ssr.process if ssr and ssr.process else [] %}
 <section id="process" class="section section--timeline" aria-labelledby="proc-title"
-        data-api="/home/process" aria-busy="false">
+        data-api="/home/process" aria-busy="false"{% if not process %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="proc-title">{{ ssr.home.section_titles.process if ssr and ssr.home.section_titles.process else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.process if ssr and ssr.home.section_subtitles.process else '' }}</p>
     </header>
     <ol class="steps" role="list">
-      {% if ssr and ssr.process %}
-        {% for it in ssr.process %}
-          <li class="step" role="listitem"><h3>{{ it.title }}</h3><p>{{ it.desc }}</p></li>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <li class="step" role="listitem">
-            <h3 data-bind="text: process[{{ i }}].title">Etap</h3>
-            <p data-bind="text: process[{{ i }}].desc">Opis etapu</p>
-          </li>
-        {% endfor %}
-      {% endif %}
+      {% for it in process %}
+        <li class="step" role="listitem"><h3>{{ it.title }}</h3><p>{{ it.desc }}</p></li>
+      {% endfor %}
     </ol>
   </div>
 </section>
@@ -290,31 +259,22 @@
 {# ================================================================
    5) TRUST — KPI kafle
    ================================================================ #}
+{% set trust = ssr.trust if ssr and ssr.trust else [] %}
 <section id="trust" class="section section--altD" aria-labelledby="trust-title"
-        data-api="/home/trust" aria-busy="false">
+        data-api="/home/trust" aria-busy="false"{% if not trust %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="trust-title">{{ ssr.home.section_titles.trust if ssr and ssr.home.section_titles.trust else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.trust if ssr and ssr.home.section_subtitles.trust else '' }}</p>
     </header>
     <div class="grid grid--kpi" role="list">
-      {% if ssr and ssr.trust %}
-        {% for it in ssr.trust %}
-          <article class="kpi" role="listitem">
-            <div class="kpi__value" data-counter="{{ it.value }}">{{ it.value }}</div>
-            <div class="kpi__label">{{ it.label }}</div>
-            <p class="kpi__desc">{{ it.desc }}</p>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <article class="kpi" role="listitem">
-            <div class="kpi__value" data-bind="text: trust[{{ i }}].value">100%</div>
-            <div class="kpi__label" data-bind="text: trust[{{ i }}].label">Wskaźnik</div>
-            <p class="kpi__desc" data-bind="text: trust[{{ i }}].desc">Opis wskaźnika</p>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for it in trust %}
+        <article class="kpi" role="listitem">
+          <div class="kpi__value" data-counter="{{ it.value }}">{{ it.value }}</div>
+          <div class="kpi__label">{{ it.label }}</div>
+          <p class="kpi__desc">{{ it.desc }}</p>
+        </article>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -322,35 +282,24 @@
 {# ================================================================
    6) TESTIMONIALS — karuzela „reel”
    ================================================================ #}
+{% set testimonials = ssr.testimonials if ssr and ssr.testimonials else [] %}
 <section id="testimonials" class="section section--altE" aria-labelledby="testi-title"
-        data-api="/home/testimonials" aria-busy="false">
+        data-api="/home/testimonials" aria-busy="false"{% if not testimonials %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="testi-title">{{ ssr.home.section_titles.testimonials if ssr and ssr.home.section_titles.testimonials else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.testimonials if ssr and ssr.home.section_subtitles.testimonials else '' }}</p>
     </header>
     <div class="reel testimonials__reel" role="list">
-      {% if ssr and ssr.testimonials %}
-        {% for t in ssr.testimonials %}
-          <figure class="quote card card--quote" role="listitem" itemprop="review" itemscope itemtype="https://schema.org/Review">
-            <blockquote class="quote__text" itemprop="reviewBody">“{{ t.quote }}”</blockquote>
-            <figcaption class="quote__meta">
-              <span class="quote__author" itemprop="author">{{ t.author }}</span>
-              <span class="quote__role">{{ t.role }}</span>
-            </figcaption>
-          </figure>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <figure class="quote card card--quote" role="listitem">
-            <blockquote class="quote__text" data-bind="text: testimonials[{{ i }}].quote">Cytat</blockquote>
-            <figcaption class="quote__meta">
-              <span class="quote__author" data-bind="text: testimonials[{{ i }}].author">Jan Kowalski</span>
-              <span class="quote__role" data-bind="text: testimonials[{{ i }}].role">Stanowisko</span>
-            </figcaption>
-          </figure>
-        {% endfor %}
-      {% endif %}
+      {% for t in testimonials %}
+        <figure class="quote card card--quote" role="listitem" itemprop="review" itemscope itemtype="https://schema.org/Review">
+          <blockquote class="quote__text" itemprop="reviewBody">“{{ t.quote }}”</blockquote>
+          <figcaption class="quote__meta">
+            <span class="quote__author" itemprop="author">{{ t.author }}</span>
+            <span class="quote__role">{{ t.role }}</span>
+          </figcaption>
+        </figure>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -358,26 +307,21 @@
 {# ================================================================
    7) PARTNERS — paski logo
    ================================================================ #}
+{% set partners = ssr.partners if ssr and ssr.partners else [] %}
 <section id="partners" class="section section--altF" aria-labelledby="partners-title"
-        data-api="/home/partners" aria-busy="false">
+        data-api="/home/partners" aria-busy="false"{% if not partners %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="partners-title">{{ ssr.home.section_titles.partners if ssr and ssr.home.section_titles.partners else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.partners if ssr and ssr.home.section_subtitles.partners else '' }}</p>
     </header>
     <ul class="logos" role="list">
-      {% if ssr and ssr.partners %}
-        {% for p in ssr.partners %}
-          <li role="listitem">
-            <img loading="lazy" decoding="async"
-                 src="{{ p.src }}" alt="{{ p.alt }}">
-          </li>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,8) %}
-          <li role="listitem"><img loading="lazy" decoding="async" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Partner" data-bind="attr: { src: partners[{{ i }}].src, alt: partners[{{ i }}].alt }"></li>
-        {% endfor %}
-      {% endif %}
+      {% for p in partners %}
+        <li role="listitem">
+          <img loading="lazy" decoding="async"
+               src="{{ p.src }}" alt="{{ p.alt }}">
+        </li>
+      {% endfor %}
     </ul>
   </div>
 </section>
@@ -385,29 +329,21 @@
 {# ================================================================
    8) FLEET — kafle
    ================================================================ #}
+{% set fleet = ssr.fleet if ssr and ssr.fleet else [] %}
 <section id="fleet" class="section section--altG" aria-labelledby="fleet-title"
-        data-api="/home/fleet" aria-busy="false">
+        data-api="/home/fleet" aria-busy="false"{% if not fleet %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="fleet-title">{{ ssr.home.section_titles.fleet if ssr and ssr.home.section_titles.fleet else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.fleet if ssr and ssr.home.section_subtitles.fleet else '' }}</p>
     </header>
     <div class="grid grid--cards" role="list">
-      {% if ssr and ssr.fleet %}
-        {% for f in ssr.fleet %}
-          <article class="card card--fleet" role="listitem">
-            <h3 class="card__title">{{ f.title }}</h3>
-            <p class="card__desc">{{ f.desc }}</p>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <article class="card card--fleet" role="listitem">
-            <h3 class="card__title" data-bind="text: fleet[{{ i }}].title">Tytuł pojazdu</h3>
-            <p class="card__desc" data-bind="text: fleet[{{ i }}].desc">Opis pojazdu</p>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for f in fleet %}
+        <article class="card card--fleet" role="listitem">
+          <h3 class="card__title">{{ f.title }}</h3>
+          <p class="card__desc">{{ f.desc }}</p>
+        </article>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -415,32 +351,23 @@
 {# ================================================================
    9) PRICING / QUOTE — kafle linkujące
    ================================================================ #}
+{% set pricing = ssr.pricing if ssr and ssr.pricing else [] %}
 <section id="pricing" class="section section--altH" aria-labelledby="pricing-title"
-        data-api="/home/pricing" aria-busy="false">
+        data-api="/home/pricing" aria-busy="false"{% if not pricing %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="pricing-title">{{ ssr.home.section_titles.pricing if ssr and ssr.home.section_titles.pricing else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.pricing if ssr and ssr.home.section_subtitles.pricing else '' }}</p>
     </header>
     <div class="grid grid--cards" role="list">
-      {% if ssr and ssr.pricing %}
-        {% for pr in ssr.pricing %}
-          <article class="card card--pricing" role="listitem">
-            <h3 class="card__title">{{ pr.title }}</h3>
-            <p class="card__desc">{{ pr.desc }}</p>
-            {% set k = pr.slugKey %}
-            <a class="card__link" href="{{ href_by_slugkey(k) }}">{{ pr.cta.label if pr.cta and pr.cta.label else '' }}</a>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,4) %}
-          <article class="card card--pricing" role="listitem">
-            <h3 class="card__title" data-bind="text: pricing[{{ i }}].title">Tytuł cennika</h3>
-            <p class="card__desc" data-bind="text: pricing[{{ i }}].desc">Opis cennika</p>
-            <a class="card__link" data-bind="href: pricing[{{ i }}].slugKey|slug, text: pricing[{{ i }}].cta.label">Sprawdź cennik</a>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for pr in pricing %}
+        <article class="card card--pricing" role="listitem">
+          <h3 class="card__title">{{ pr.title }}</h3>
+          <p class="card__desc">{{ pr.desc }}</p>
+          {% set k = pr.slugKey %}
+          <a class="card__link" href="{{ href_by_slugkey(k) }}">{{ pr.cta.label if pr.cta and pr.cta.label else '' }}</a>
+        </article>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -448,31 +375,22 @@
 {# ================================================================
    10) INSIGHTS — blog/cases (reel)
    ================================================================ #}
+{% set blog = ssr.blog if ssr and ssr.blog else [] %}
 <section id="insights" class="section section--altI" aria-labelledby="ins-title"
-        data-api="/blog/latest" aria-busy="false">
+        data-api="/blog/latest" aria-busy="false"{% if not blog %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="ins-title">{{ ssr.home.section_titles.insights if ssr and ssr.home.section_titles.insights else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.insights if ssr and ssr.home.section_subtitles.insights else '' }}</p>
     </header>
     <div class="reel insights__reel" role="list">
-      {% if ssr and ssr.blog %}
-        {% for b in ssr.blog %}
-          <article class="card card--post" role="listitem" itemscope itemtype="https://schema.org/BlogPosting">
-            <h3 class="card__title" itemprop="headline">{{ b.title }}</h3>
-            <p class="card__desc" itemprop="description">{{ b.lead }}</p>
-            <a class="card__link" href="{{ b.canonical_path }}">{{ b.cta.label if b.cta and b.cta.label else '' }}</a>
-          </article>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,6) %}
-          <article class="card card--post" role="listitem">
-            <h3 class="card__title" data-bind="text: blog[{{ i }}].title">Tytuł wpisu</h3>
-            <p class="card__desc" data-bind="text: blog[{{ i }}].lead">Zajawka wpisu</p>
-            <a class="card__link" data-bind="href: blog[{{ i }}].canonical_path, text: blog[{{ i }}].cta.label">Czytaj więcej</a>
-          </article>
-        {% endfor %}
-      {% endif %}
+      {% for b in blog %}
+        <article class="card card--post" role="listitem" itemscope itemtype="https://schema.org/BlogPosting">
+          <h3 class="card__title" itemprop="headline">{{ b.title }}</h3>
+          <p class="card__desc" itemprop="description">{{ b.lead }}</p>
+          <a class="card__link" href="{{ b.canonical_path }}">{{ b.cta.label if b.cta and b.cta.label else '' }}</a>
+        </article>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -480,29 +398,21 @@
 {# ================================================================
    11) FAQ — details/summary
    ================================================================ #}
+{% set faq = ssr.faq if ssr and ssr.faq else [] %}
 <section id="faq" class="section section--faq" aria-labelledby="faq-title"
-        data-api="/faq/list" aria-busy="false">
+        data-api="/faq/list" aria-busy="false"{% if not faq %} hidden{% endif %}>
   <div class="wrap">
     <header class="section__head">
       <h2 id="faq-title">{{ ssr.home.section_titles.faq if ssr and ssr.home.section_titles.faq else '' }}</h2>
       <p class="section__sub">{{ ssr.home.section_subtitles.faq if ssr and ssr.home.section_subtitles.faq else '' }}</p>
     </header>
     <div class="faq-list" role="list">
-      {% if ssr and ssr.faq %}
-        {% for f in ssr.faq %}
-          <details class="qa" role="listitem">
-            <summary>{{ f.q }}</summary>
-            <div class="a"><p>{{ f.a }}</p></div>
-          </details>
-        {% endfor %}
-      {% else %}
-        {% for i in range(0,12) %}
-          <details class="qa" role="listitem">
-            <summary data-bind="text: faq[{{ i }}].q">Pytanie</summary>
-            <div class="a"><p data-bind="text: faq[{{ i }}].a">Odpowiedź</p></div>
-          </details>
-        {% endfor %}
-      {% endif %}
+      {% for f in faq %}
+        <details class="qa" role="listitem">
+          <summary>{{ f.q }}</summary>
+          <div class="a"><p>{{ f.a }}</p></div>
+        </details>
+      {% endfor %}
     </div>
   </div>
 </section>
@@ -510,21 +420,22 @@
 {# ================================================================
    12) FINAL CTA — przyciski
    ================================================================ #}
+{% set final = ssr.final if ssr and ssr.final else {} %}
 <section id="final-cta" class="section section--final" data-api="/home/final"
-        aria-labelledby="final-cta-title" aria-busy="false">
+        aria-labelledby="final-cta-title" aria-busy="false"{% if not final %} hidden{% endif %}>
   <div class="wrap">
-    <h2 id="final-cta-title">{{ ssr.final.title if ssr and ssr.final and ssr.final.title else '' }}</h2>
-    <p class="final__desc">{{ ssr.final.desc if ssr and ssr.final and ssr.final.desc else '' }}</p>
+    {% if final.title %}<h2 id="final-cta-title">{{ final.title }}</h2>{% endif %}
+    {% if final.desc %}<p class="final__desc">{{ final.desc }}</p>{% endif %}
     <div class="cta-row">
       <a class="btn btn-primary"
          href="{{ href_by_slugkey('quote') }}"
          data-bind="href: final.cta_primary.slugKey|slug, text: final.cta_primary.label">
-        {{ ssr.final.cta_primary.label if ssr and ssr.final and ssr.final.cta_primary else STR('cta_quote_primary') }}
+        {{ final.cta_primary.label if final and final.cta_primary else STR('cta_quote_primary') }}
       </a>
       <a class="btn btn-ghost"
          href="{{ href_by_slugkey('contact') }}"
          data-bind="href: final.cta_secondary.slugKey|slug, text: final.cta_secondary.label">
-        {{ ssr.final.cta_secondary.label if ssr and ssr.final and ssr.final.cta_secondary else STR('cta_quote_secondary') }}
+        {{ final.cta_secondary.label if final and final.cta_secondary else STR('cta_quote_secondary') }}
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Render home sections only when server-side data exists
- Hide empty sections for client-side hydration instead of showing placeholders

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ac712d66c4833381e4831267b99ed7