### PR TITLE
fix(nav): delegate clicks for mega menu + aria

### DIFF
--- a/tests/test_bind_mega.py
+++ b/tests/test_bind_mega.py
@@ -24,7 +24,6 @@ def test_bind_mega_initial_and_dynamic():
         document.getElementById('navList').innerHTML += `\n      <li class='has-mega'>\n        <button class='mega-toggle' aria-expanded='false' aria-controls='mega-b'>B</button>\n        <div id='mega-b' hidden aria-hidden='true'></div>\n      </li>`
         """)
         page.wait_for_selector("button[aria-controls='mega-b']")
-        page.wait_for_function("document.querySelector(\"button[aria-controls='mega-b']\").dataset.megaBound === '1'")
         page.click("button[aria-controls='mega-b']")
         assert page.get_attribute("button[aria-controls='mega-b']", 'aria-expanded') == 'true'
         assert page.get_attribute("#mega-b", 'hidden') is None


### PR DESCRIPTION
## Summary
- delegate mega menu toggles via document click listener
- toggle aria-expanded/aria-hidden and close other panels in same list
- close mega menus on Escape or outside clicks; expose `toggleMega`

## Testing
- `pytest tests/test_bind_mega.py tests/test_menu_aria_hidden.py` *(fails: BrowserType.launch: Executable doesn't exist...)*
- `playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68ac79326f848333a47cd9034aed37e8