### PR TITLE
fix(header): proper hidden mega + z-index and pointer-events

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -91,17 +91,18 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .section--altI{background:linear-gradient(180deg, rgba(244,63,94,.05), transparent 50%)}
 
 /* ================= HEADER (Squarespace-style) ================= */
-#site-header.site-header{
-  position:sticky; top:0; z-index:60; background:var(--bg-elev);
+/* Header */
+.site-header{
+  position:sticky; top:0; z-index:1100; background:var(--bg-elev);
   backdrop-filter:saturate(180%) blur(12px);
   border-bottom:1px solid var(--line);
   transition:box-shadow .25s ease, background .25s ease;
 }
-#site-header.site-header.sq--shadow{box-shadow:0 8px 20px rgba(0,0,0,.06)}
-#site-header.site-header.is-sticky{box-shadow:0 8px 20px rgba(0,0,0,.06)}
-#site-header.site-header.is-shrunk .bar{padding-block:6px}
+.site-header.sq--shadow{box-shadow:0 8px 20px rgba(0,0,0,.06)}
+.site-header.is-sticky{box-shadow:0 8px 20px rgba(0,0,0,.06)}
+.site-header.is-shrunk .bar{padding-block:6px}
 .site-header.is-hidden{transform:translateY(-100%);transition:transform .25s var(--mega-ease)}
-#site-header .bar{
+.site-header .bar{
   display:grid; grid-template-columns:160px 1fr auto; align-items:center; gap:10px;
   padding-block:10px;
   transition:padding .2s ease;
@@ -165,8 +166,7 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 
 /* ================= MEGA PANEL (CMS-injected) ================= */
 #mega.mega{
-  position:absolute; left:0; right:0; top:100%; z-index:55;
-  /* domyślnie schowany; JS steruje [data-state] i --mega-h */
+  position:absolute; left:0; right:0; top:100%; z-index:1000;
   pointer-events:none; transform:translateY(-8px); opacity:0;
   background:color-mix(in oklab, var(--bg) 92%, transparent);
   backdrop-filter:saturate(180%) blur(10px);
@@ -174,7 +174,7 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
   box-shadow:0 16px 30px rgba(0,0,0,.08);
   transition:transform .24s var(--mega-ease), opacity .24s var(--mega-ease);
 }
-#mega[data-state="open"]{pointer-events:auto; transform:translateY(0); opacity:1}
+#mega:not([hidden]){pointer-events:auto; transform:translateY(0); opacity:1}
 #mega .mega__wrap{padding-block:14px 18px}
 #megaPanels.mega__panels{max-height:var(--mega-h); overflow:hidden; transition:max-height .28s var(--mega-ease)}
 
@@ -206,7 +206,7 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .mega .list li a:hover::after{opacity:.9; transform:translateX(2px) rotate(-45deg)}
 
 /* Cień paska przy aktywnym mega */
-#site-header.site-header[data-mega="open"]{box-shadow:0 10px 24px rgba(0,0,0,.08)}
+.site-header[data-mega="open"]{box-shadow:0 10px 24px rgba(0,0,0,.08)}
 
 /* Mobile: mega wyłączony, używamy drawer */
 @media (max-width:980px){ #mega{display:none !important} }
@@ -348,26 +348,42 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .has-mega{position:relative;display:inline-flex;align-items:center}
 .has-mega>.mega-toggle{margin-left:-4px}
 .mega-toggle{background:none;border:0;padding:8px 10px;border-radius:8px;cursor:pointer}
-.mega{position:absolute;left:50%;transform:translateX(-50%);top:120%;width:100vw;max-width:1200px;background:#fff;border:1px solid #e5e7eb;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.08);padding:20px;display:none;z-index:1000}
+.mega,
+.mega-panel{
+  position:absolute;
+  left:0;
+  top:100%;
+  width:100%;
+  background:#fff;
+  box-shadow:0 10px 30px rgba(0,0,0,.08);
+  border:1px solid #e5e7eb;
+  border-radius:16px;
+  padding:20px;
+  pointer-events:none;
+  z-index:1000;
+}
+.mega:not([hidden]),
+.mega-panel:not([hidden]){pointer-events:auto;}
+.mega[hidden],
+.mega-panel[hidden]{display:none!important;}
 .mega-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:20px}
 .mega-col ul{list-style:none;margin:0;padding:0}
-.has-mega>.mega-toggle[aria-expanded="true"]+.mega{display:block;pointer-events:auto}
 @media(max-width:960px){
-  .mega{position:static;transform:none;width:auto;display:block}
+  .mega{position:static;transform:none;width:auto}
   .mega-grid{grid-template-columns:1fr}
 }
 
 /* === Minimal header layout === */
-#site-header{
+.site-header{
   position:sticky;
   top:0;
   background:#fff;
   border-bottom:1px solid #e5e7eb;
-  z-index:1000;
+  z-index:1100;
   transition:padding .2s ease;
 }
-#site-header.is-shrunk .bar{padding-block:4px;}
-#site-header .bar{
+.site-header.is-shrunk .bar{padding-block:4px;}
+.site-header .bar{
   display:flex;
   align-items:center;
   justify-content:space-between;
@@ -376,15 +392,15 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
   padding:12px 20px;
   gap:16px;
 }
-#site-header .actions{display:flex;align-items:center;gap:16px;}
-#site-header .btn-cta{
+.site-header .actions{display:flex;align-items:center;gap:16px;}
+.site-header .btn-cta{
   background:#0ea5e9;
   color:#fff;
   border-radius:999px;
   padding:8px 18px;
   font-weight:600;
 }
-#site-header .hamburger{
+.site-header .hamburger{
   display:none;
   width:40px;
   height:40px;
@@ -393,8 +409,8 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
   background:transparent;
 }
 @media(max-width:980px){
-  #site-header nav{display:none;}
-  #site-header .hamburger{display:block;}
+  .site-header nav{display:none;}
+  .site-header .hamburger{display:block;}
 }
 #mobile-nav{
   position:fixed;


### PR DESCRIPTION
## Summary
- hide mega panels via `[hidden]` to remove overlay and toggle pointer events
- raise `site-header` stacking to stay above page content
- scope pointer-events to visible panels only

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist; run `playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8839085c833390f3645fa7e58c6a