### PR TITLE
refactor header partial

### DIFF
--- a/templates/_partials/header_new.html
+++ b/templates/_partials/header_new.html
@@ -9,6 +9,13 @@
         data-theme-sun="/assets/flags/theme-sun.svg"
         data-theme-moon="/assets/flags/theme-moon.svg"
         aria-busy="true">
+  {% set _nav_items = nav_data.primary or [] %}
+  {% set _cta_label = (nav_data.cta.label if nav_data.cta else 'Zamów wycenę') %}
+  {% set _cta_href  = (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') %}
+  {% set _lang_items = nav_data.langs or [] %}
+  {% set _routes = nav_data.routes or {} %}
+  {% set _social = nav_data.social or {} %}
+  {% set _mega_panels = nav_data.mega or {} %}
 
   <!-- ============== CRITICAL CSS (scoped do #site-header) ============== -->
   <style>
@@ -142,7 +149,7 @@
 
     <nav id="primaryNav" class="nav sq-nav" role="navigation" aria-label="Główne menu">
       <ul class="nav__list" id="navList">
-        {% for item in (nav_data.primary or []) %}
+        {% for item in _nav_items %}
           {% if item.cols %}
             {% set mid = 'm-' ~ loop.index %}
             <li class="has-mega" data-panel="{{ mid }}">
@@ -163,14 +170,13 @@
       <span id="statusPill" class="status-pill" hidden>🚚 auto wolne</span>
 
       {% set _slug = page.slugKey or page.slug or 'home' %}
-      {% set _routes = nav_data.routes or {} %}
       <div class="langs" id="langsWrap">
         <button id="langBtn" class="lang-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="langsDd">
           <img class="flag" id="langFlag" src="/assets/flags/{{ 'gb' if (page.lang or 'pl') == 'en' else (page.lang or 'pl') }}.svg" alt="" width="18" height="12"><span id="langCode">{{ (page.lang or 'pl')|upper }}</span>
           <svg class="chev" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M5.2 7.6 10 12.4l4.8-4.8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div id="langsDd" class="lang-dd" role="menu" aria-hidden="true" aria-label="Wybór języka">
-          {% for l in (nav_data.langs or []) %}
+          {% for l in _lang_items %}
             {% set rel = (_routes.get(_slug, {}) or {}).get(l.code, '') %}
             {% set href = '/' ~ l.code ~ '/' ~ (rel ~ '/' if rel) %}
             <a href="{{ href }}" hreflang="{{ l.code }}"{% if l.code == (page.lang or 'pl') %} aria-current="true"{% endif %}><img class="flag" src="{{ l.flag }}" alt="" width="18" height="12">{{ l.code|upper }}</a>
@@ -189,26 +195,25 @@
         </div>
       </div>
 
-      {% set social = nav_data.social or {} %}
       <div class="social" id="social">
-        {% if social.ig %}
-        <a id="ig" href="{{ social.ig }}" aria-label="Instagram" rel="noopener" target="_blank">
+        {% if _social.ig %}
+        <a id="ig" href="{{ _social.ig }}" aria-label="Instagram" rel="noopener" target="_blank">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 2.2a2.8 2.8 0 1 0 0 5.6 2.8 2.8 0 0 0 0-5.6Zm5.35-.95a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Z"/></svg>
         </a>
         {% endif %}
-        {% if social.li %}
-        <a id="li" href="{{ social.li }}" aria-label="LinkedIn" rel="noopener" target="_blank">
+        {% if _social.li %}
+        <a id="li" href="{{ _social.li }}" aria-label="LinkedIn" rel="noopener" target="_blank">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5c0 1.38-1.12 2.5-2.49 2.5A2.5 2.5 0 0 1 0 3.5 2.5 2.5 0 0 1 2.49 1c1.37 0 2.49 1.12 2.49 2.5ZM.5 8.5h4V23h-4V8.5Zm7.5 0h3.84v1.98h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.77 2.65 4.77 6.1V23h-4v-5.87c0-1.4-.03-3.2-1.95-3.2-1.95 0-2.25 1.52-2.25 3.1V23h-4V8.5Z"/></svg>
         </a>
         {% endif %}
-        {% if social.fb %}
-        <a id="fb" href="{{ social.fb }}" aria-label="Facebook" rel="noopener" target="_blank">
+        {% if _social.fb %}
+        <a id="fb" href="{{ _social.fb }}" aria-label="Facebook" rel="noopener" target="_blank">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12.07C22 6.48 17.52 2 11.93 2S2 6.48 2 12.07C2 17.1 5.66 21.25 10.44 22v-7.04H7.9v-2.9h2.54V9.85c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.46h-1.26c-1.24 0-1.63.77-1.63 1.56v1.87h2.78l-.44 2.9h-2.34V22C18.34 21.25 22 17.1 22 12.07Z"/></svg>
         </a>
         {% endif %}
       </div>
 
-      <a id="cta" class="btn btn-primary" href="{{ (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') }}">{{ (nav_data.cta.label if nav_data.cta else 'Zamów wycenę') }}</a>
+      <a id="cta" class="btn btn-primary" href="{{ _cta_href }}">{{ _cta_label }}</a>
       <button id="menuToggle" class="menu-toggle" aria-expanded="false" aria-controls="mobileMenu" aria-label="Menu"></button>
     </div>
   </div>
@@ -217,7 +222,7 @@
     <div class="mega__wrap wrap">
       <div class="mega__grid-wrap">
         <div class="mega__panels" id="megaPanels">
-          {% for item in (nav_data.primary or []) %}
+          {% for item in _nav_items %}
             {% if item.cols %}
               {% set mid = 'm-' ~ loop.index %}
               <section id="panel-{{ mid }}" class="mega__section" data-panel="{{ mid }}">
@@ -247,7 +252,7 @@
               </section>
             {% endif %}
           {% endfor %}
-          {% for pid, panel in (nav_data.mega or {}).items() %}
+          {% for pid, panel in _mega_panels.items() %}
             <section id="panel-{{ pid }}" class="mega__section" data-panel="{{ pid }}">
               <div class="mega__grid">
                 {% for col in (panel.columns or []) %}
@@ -277,7 +282,7 @@
       </div>
       <nav class="mobile-nav" aria-label="Nawigacja mobilna">
         <ul class="mobile-nav__list" id="mobileList">
-          {% for item in (nav_data.primary or []) %}
+          {% for item in _nav_items %}
             {% if item.cols %}
               {% set mid = 'm-' ~ loop.index %}
               <li class="has-children">
@@ -311,14 +316,14 @@
       </nav>
       <div class="mobile-langs" id="mobileLangs">
         <div class="lang-dd" style="display:grid;grid-auto-rows:min-content" aria-hidden="false">
-          {% for l in (nav_data.langs or []) %}
+          {% for l in _lang_items %}
             {% set rel = (_routes.get(_slug, {}) or {}).get(l.code, '') %}
             {% set href = '/' ~ l.code ~ '/' ~ (rel ~ '/' if rel) %}
             <a href="{{ href }}" hreflang="{{ l.code }}"{% if l.code == (page.lang or 'pl') %} aria-current="true"{% endif %}><img class="flag" src="{{ l.flag }}" alt="" width="18" height="12">{{ l.code|upper }}</a>
           {% endfor %}
         </div>
       </div>
-      <a class="btn btn-primary mobile-cta" id="mobileCTA" href="{{ (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') }}">{{ (nav_data.cta.label if nav_data.cta else 'Zamów wycenę') }}</a>
+      <a class="btn btn-primary mobile-cta" id="mobileCTA" href="{{ _cta_href }}">{{ _cta_label }}</a>
     </div>
   </div>
 
@@ -330,9 +335,9 @@
       <li><a id="dockWA" href="#" aria-label="WhatsApp">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M.5 23.5 3 17.9a10 10 0 1 1 3.8 3.6L.5 23.5Zm6.7-3.8.3.2a8.3 8.3 0 1 0-2.7-2.6l.2.3-1.2 3.2 3.4-1.1Zm9.8-3.8c-.1 0-.1 0 0 0-1.3-.7-2.9-1.2-3.3-1.3-.5-.1-.9 0-1.2.5s-1.1 1.3-1.4 1.5c-.2.2-.4.2-.7.1a6.7 6.7 0 0 1-2-1.2 7.5 7.5 0 0 1-1.6-2c-.2-.4 0-.6.2-.8l.5-.6c.2-.3.2-.5 0-.8l-.8-2c-.2-.5-.5-.6-1-.5h-.8c-.3 0-.7.2-.9.4-1 1-1.1 2.6-.3 4.3.8 1.6 2.4 3.6 4.8 4.7 1.7.7 3 .9 4 .6.7-.2 1.3-.7 1.5-1.3.2-.5.2-1 .2-1.2-.1-.2-.3-.3-.6-.4Z"/></svg>
         <span>WhatsApp</span></a></li>
-      <li><a id="dockQuote" href="{{ (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') }}" class="btn-primary" aria-label="{{ (nav_data.cta.label if nav_data.cta else 'Wycena') }}">
+      <li><a id="dockQuote" href="{{ _cta_href }}" class="btn-primary" aria-label="{{ _cta_label }}">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M21 6H8a2 2 0 0 0-2 2v8h2V8h13V6ZM5 10H3v10c0 1.1.9 2 2 2h12v-2H5V10Zm16 3h-8v2h8v-2Zm0 4h-8v2h8v-2Zm0-8h-8v2h8V9Z"/></svg>
-        <span>{{ (nav_data.cta.label if nav_data.cta else 'Wycena') }}</span></a></li>
+        <span>{{ _cta_label }}</span></a></li>
       <li><a id="dockMenu" href="#mobileMenu" aria-label="Menu">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 6h18v2H3V6Zm0 5h18v2H3v-2Zm0 5h18v2H3v-2Z"/></svg>
         <span>Menu</span></a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -144,7 +144,7 @@
   <script>document.documentElement.classList.remove('no-js');</script>
 </head>
   <body>
-    {% include "_partials/header.html" %}
+    {% include "_partials/header_new.html" %}
 
     <main id="main" tabindex="-1" role="main">
     {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- inline navigation data variables in new header partial
- switch base template to new `header_new` partial and retire old header

## Testing
- `python tools/build.py`
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ace5e0e21c833381f6879c08c54fc4