### PR TITLE
Use nav_data in header snippet

### DIFF
--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -164,19 +164,22 @@
 
       {% set _slug = page.slugKey or page.slug or 'home' %}
       {% set _routes = nav_data.routes or {} %}
+      {% set _langs = nav_data.langs or [] %}
+      {% if _langs|length > 1 %}
       <div class="langs" id="langsWrap">
         <button id="langBtn" class="lang-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="langsDd">
           <img class="flag" id="langFlag" src="/assets/flags/{{ 'gb' if (page.lang or 'pl') == 'en' else (page.lang or 'pl') }}.svg" alt="" width="18" height="12"><span id="langCode">{{ (page.lang or 'pl')|upper }}</span>
           <svg class="chev" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M5.2 7.6 10 12.4l4.8-4.8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div id="langsDd" class="lang-dd" role="menu" aria-hidden="true" aria-label="Wybór języka">
-          {% for l in (nav_data.langs or []) %}
+          {% for l in _langs %}
             {% set rel = (_routes.get(_slug, {}) or {}).get(l.code, '') %}
             {% set href = '/' ~ l.code ~ '/' ~ (rel ~ '/' if rel) %}
             <a href="{{ href }}" hreflang="{{ l.code }}"{% if l.code == (page.lang or 'pl') %} aria-current="true"{% endif %}><img class="flag" src="{{ l.flag }}" alt="" width="18" height="12">{{ l.code|upper }}</a>
           {% endfor %}
         </div>
       </div>
+      {% endif %}
 
       <div class="theme" id="themeWrap">
         <button id="themeBtn" class="theme-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="themeDd">
@@ -190,6 +193,9 @@
       </div>
 
       {% set social = nav_data.social or {} %}
+      {% set _cta = nav_data.cta or {} %}
+      {% set cta_href = _cta.href or '/pl/kontakt/' %}
+      {% set cta_label = _cta.label or 'Zamów wycenę' %}
       <div class="social" id="social">
         {% if social.ig %}
         <a id="ig" href="{{ social.ig }}" aria-label="Instagram" rel="noopener" target="_blank">
@@ -208,7 +214,7 @@
         {% endif %}
       </div>
 
-      <a id="cta" class="btn btn-primary" href="{{ (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') }}">{{ (nav_data.cta.label if nav_data.cta else 'Zamów wycenę') }}</a>
+      <a id="cta" class="btn btn-primary" href="{{ cta_href }}">{{ cta_label }}</a>
       <button id="menuToggle" class="menu-toggle" aria-expanded="false" aria-controls="mobileMenu" aria-label="Menu"></button>
     </div>
   </div>
@@ -309,16 +315,18 @@
           {% endfor %}
         </ul>
       </nav>
+      {% if _langs|length > 1 %}
       <div class="mobile-langs" id="mobileLangs">
         <div class="lang-dd" style="display:grid;grid-auto-rows:min-content" aria-hidden="false">
-          {% for l in (nav_data.langs or []) %}
+          {% for l in _langs %}
             {% set rel = (_routes.get(_slug, {}) or {}).get(l.code, '') %}
             {% set href = '/' ~ l.code ~ '/' ~ (rel ~ '/' if rel) %}
             <a href="{{ href }}" hreflang="{{ l.code }}"{% if l.code == (page.lang or 'pl') %} aria-current="true"{% endif %}><img class="flag" src="{{ l.flag }}" alt="" width="18" height="12">{{ l.code|upper }}</a>
           {% endfor %}
         </div>
       </div>
-      <a class="btn btn-primary mobile-cta" id="mobileCTA" href="{{ (nav_data.cta.href if nav_data.cta else '/pl/kontakt/') }}">{{ (nav_data.cta.label if nav_data.cta else 'Zamów wycenę') }}</a>
+      {% endif %}
+      <a class="btn btn-primary mobile-cta" id="mobileCTA" href="{{ cta_href }}">{{ cta_label }}</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- read nav menu data from `nav_data` for language switcher and CTA
- conditionally render language selector based on `nav_data.langs`
- centralize CTA link/label using `nav_data.cta`

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `playwright install chromium` *(fails: Download failed 403 Domain forbidden)*
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68ace5fa22fc8333a935f55242ecd5d7