### PR TITLE
refactor: move header styles to shared stylesheet

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -90,152 +90,123 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .section--altH{background:linear-gradient(180deg, rgba(168,85,247,.06), transparent 50%)}
 .section--altI{background:linear-gradient(180deg, rgba(244,63,94,.05), transparent 50%)}
 
-/* ================= HEADER (Squarespace-style) ================= */
-/* Header */
-.site-header{
-  position:sticky; top:0; z-index:1100; background:var(--bg-elev);
-  backdrop-filter:saturate(180%) blur(12px);
-  border-bottom:1px solid var(--line);
-  transition:box-shadow .25s ease, background .25s ease;
-}
-.site-header.sq--shadow{box-shadow:0 8px 20px rgba(0,0,0,.06)}
-.site-header.is-sticky{box-shadow:0 8px 20px rgba(0,0,0,.06)}
-.site-header.is-shrunk .bar{padding-block:6px}
-.site-header.is-hidden{transform:translateY(-100%);transition:transform .25s var(--mega-ease)}
-.site-header .bar{
-  display:grid; grid-template-columns:160px 1fr auto; align-items:center; gap:10px;
-  padding-block:10px;
-  transition:padding .2s ease;
-}
-.brand{display:inline-flex; align-items:center; gap:10px; padding:4px 0}
-.actions{display:flex; gap:10px; align-items:center}
 
-/* ---------- Burger (mobile) ---------- */
-#menuToggle.menu-toggle,
-.menu-toggle{
-  width:40px; height:40px; border-radius:12px; border:1px solid var(--line); background:transparent;
-  position:relative; display:none;
-}
-.menu-toggle::before,.menu-toggle::after{
-  content:""; position:absolute; left:10px; right:10px; height:2px; background:currentColor; transition:.25s var(--mega-ease)
-}
-.menu-toggle::before{top:14px} .menu-toggle::after{bottom:14px}
-.menu-toggle[aria-expanded="true"]::before{transform:translateY(6px) rotate(45deg)}
-.menu-toggle[aria-expanded="true"]::after{transform:translateY(-6px) rotate(-45deg)}
-@media (max-width:980px){ .sq-nav{display:none} .menu-toggle{display:inline-block} }
+    #site-header{--bg:rgba(255,255,255,.82);--ink:#0b1020;--ink-weak:#64748b;--line:rgba(0,0,0,.08);
+      --brand:#0ea5e9;--ease:cubic-bezier(.2,.7,.2,1);--mega-h:0px;--fs-header:clamp(.75rem,2.2vw,1rem)}
+    @media (prefers-color-scheme:dark){
+      #site-header{--bg:rgba(15,23,42,.62);--ink:#e5e7eb;--ink-weak:#94a3b8;--line:rgba(255,255,255,.10)}
+    }
+    #site-header{position:sticky;top:0;z-index:60;background:var(--bg);
+      -webkit-backdrop-filter:saturate(180%) blur(12px);backdrop-filter:saturate(180%) blur(12px);
+      border-bottom:1px solid var(--line);transition:box-shadow .25s ease, background .25s ease}
+    #site-header.s--shadow{box-shadow:0 8px 22px rgba(0,0,0,.08)}
+    #site-header .wrap{max-width:980px;margin:0 auto;padding:0 12px 0 8px}
+    @media (min-width:768px){ #site-header .wrap{padding:0 18px 0 12px} }
 
-/* ================= PRIMARY NAV (single row) ================= */
-.sq-nav{position:relative}
-.sq-nav::before,.sq-nav::after{
-  content:""; position:absolute; top:0; bottom:0; width:24px; pointer-events:none; z-index:1;
-}
-.sq-nav::before{left:0;  background:linear-gradient(90deg, var(--bg-elev), transparent)}
-.sq-nav::after{ right:0; background:linear-gradient(-90deg, var(--bg-elev), transparent)}
+    .bar{display:grid;grid-template-columns:minmax(120px,170px) 1fr auto;gap:10px;justify-items:center;align-items:center;padding:6px 0}
+    #site-header a{color:inherit;text-decoration:none}
+    .brand{display:inline-flex;align-items:center;gap:10px}
+    .brand__logo{height:auto;width:clamp(90px,24vw,160px);transition:transform .18s ease,filter .18s ease}
+    .brand:hover .brand__logo{transform:scale(1.045);filter:drop-shadow(0 6px 18px rgba(14,165,233,.28))}
 
-#navList,
-.sq-nav .nav__list{
-  list-style:none; margin:0; padding:0;
-  display:flex; gap:6px; align-items:center;
-  flex-wrap:nowrap; overflow-x:auto; /* single-row horizontal scroll */
-  -webkit-overflow-scrolling:touch;
-  scroll-behavior:smooth;
-}
-#navList::-webkit-scrollbar{height:8px}
-#navList::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15); border-radius:999px}
-@media (prefers-color-scheme:dark){ #navList::-webkit-scrollbar-thumb{background:rgba(255,255,255,.18)} }
+    .nav__list{list-style:none;margin:0;padding:0;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+    .nav__list>li{position:relative}
+    .nav__list>li>a,.nav__list>li>button{appearance:none;background:transparent;border:0;color:inherit;font:inherit;line-height:1;cursor:pointer;
+      padding:8px 10px;border-radius:12px;display:inline-flex;align-items:center;gap:6px;white-space:nowrap;font-size:var(--fs-header)}
+    .nav__list>li:hover>a{background:rgba(0,0,0,.04)}
+    @media (prefers-color-scheme:dark){ .nav__list>li:hover>a{background:rgba(255,255,255,.06)}}
 
-#navList > li{position:relative; flex:0 0 auto}
-#navList > li > a,
-#navList > li > button{
-  appearance:none; background:transparent; border:0; color:inherit; font:inherit; line-height:1;
-  padding:10px 12px; border-radius:12px; display:inline-flex; align-items:center; gap:6px;
-  white-space:nowrap; cursor:pointer;
-}
-#navList > li > a[aria-current="page"]{font-weight:600}
-#navList > li:hover > a{background:rgba(0,0,0,.04); text-decoration:none}
-@media (prefers-color-scheme:dark){ #navList > li:hover > a{background:rgba(255,255,255,.06)} }
+    .actions{display:flex;align-items:center;gap:10px}
+    .btn{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:14px;border:1px solid var(--line);
+      background:#fff;font-weight:700;font-size:var(--fs-header);color:var(--ink);transition:transform .15s ease, background .2s ease}
+    .btn:hover{transform:translateY(-1px)}
+    @media (prefers-color-scheme:dark){ .btn{background:rgba(255,255,255,.06)}}
+    .btn-primary{background:var(--brand);border-color:transparent;color:#fff}
 
-/* Mały wskaźnik, że item otwiera panel */
-#navList > li[data-panel] > a::after{
-  content:""; width:8px; height:8px; margin-left:6px;
-  border:2px solid currentColor; border-top:0; border-left:0;
-  transform:rotate(45deg) translateY(-1px); opacity:.7;
-  transition:transform .18s ease, opacity .18s ease;
-}
-#navList > li[data-panel]:hover > a::after{transform:rotate(225deg) translateY(1px); opacity:1}
+    .langs{position:relative}
+    .lang-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:12px;border:1px solid var(--line);background:#fff}
+    @media (prefers-color-scheme:dark){ .lang-btn{background:rgba(255,255,255,.06)}}
+    .flag{width:18px;height:12px;border-radius:3px;border:1px solid var(--line);object-fit:cover}
+    .chev{width:14px;height:14px;opacity:.7}
+    .lang-dd{position:absolute;right:0;top:100%;margin-top:8px;min-width:180px;background:var(--bg);
+      border:1px solid var(--line);border-radius:12px;box-shadow:0 12px 28px rgba(10,10,20,.12);padding:6px;display:none}
+    .lang-dd[aria-hidden="false"]{display:block}
+    .lang-dd a{display:flex;align-items:center;gap:8px;padding:8px;border-radius:10px}
+    .lang-dd a[aria-current="true"]{outline:2px solid var(--line)}
+    .lang-dd a:hover{background:rgba(0,0,0,.04)}
+    @media (prefers-color-scheme:dark){ .lang-dd a:hover{background:rgba(255,255,255,.06)}}
 
-/* ================= MEGA PANEL (CMS-injected) ================= */
-#mega.mega{
-  position:absolute; left:0; right:0; top:100%; z-index:1000;
-  pointer-events:none; transform:translateY(-8px); opacity:0;
-  background:color-mix(in oklab, var(--bg) 92%, transparent);
-  backdrop-filter:saturate(180%) blur(10px);
-  border-bottom:1px solid var(--line);
-  box-shadow:0 16px 30px rgba(0,0,0,.08);
-  transition:transform .24s var(--mega-ease), opacity .24s var(--mega-ease);
-}
-#mega:not([hidden]){pointer-events:auto; transform:translateY(0); opacity:1}
-#mega .mega__wrap{padding-block:14px 18px}
-#megaPanels.mega__panels{max-height:var(--mega-h); overflow:hidden; transition:max-height .28s var(--mega-ease)}
+    .theme{position:relative}
+    .theme-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:12px;border:1px solid rgba(255,255,255,.18);background:#fff}
+    @media (prefers-color-scheme:dark){ .theme-btn{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.28)}}
+    .theme-btn img{width:16px;height:16px}
+    .theme-dd{position:absolute;right:0;top:100%;margin-top:8px;min-width:160px;background:var(--bg);
+      border:1px solid var(--line);border-radius:12px;box-shadow:0 12px 28px rgba(10,10,20,.12);padding:6px;display:none}
+    .theme-dd[aria-hidden="false"]{display:block}
+    .theme-dd button{width:100%;text-align:left;padding:8px;border:0;background:transparent;border-radius:10px;display:flex;gap:8px;align-items:center}
+    .theme-dd button:hover{background:rgba(0,0,0,.04)}
+    @media (prefers-color-scheme:dark){ .theme-dd button:hover{background:rgba(255,255,255,.06)}}
 
-.mega__section{padding:4px 0 8px; display:none}
-.mega__section.is-active{display:block}
+    .social{display:flex;gap:8px;margin-left:6px}
+    .social a{display:inline-flex;padding:8px;border-radius:50%}
+    .status-pill{margin-left:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--line);
+      font-weight:600;font-size:var(--fs-header);color:var(--ink-weak);background:rgba(14,165,233,.08)}
 
+    @media (max-width:600px){
+      .bar{grid-template-columns:auto 1fr}
+      .bar>*{min-width:0}
+      .actions{flex-wrap:wrap}
+      .actions>*{flex:1 1 auto;min-width:0}
+      .btn{max-width:100%;box-sizing:border-box;padding:6px 8px;font-size:var(--fs-header)}
+      .social,.status-pill{display:none}
+    }
 
-.mega .card{
-  display:block; background:#fff; border:1px solid var(--line);
-  border-radius:var(--radius); padding:12px; box-shadow:var(--shadow);
-  transition:transform .16s ease, box-shadow .16s ease, background .16s ease;
-}
-.mega .card a{display:block; color:inherit; text-decoration:none}
-.mega .card:hover{transform:translateY(-2px); box-shadow:0 14px 28px rgba(0,0,0,.12)}
-.mega .card:focus-within{outline:3px solid var(--brand-2); outline-offset:2px}
-@media (prefers-color-scheme:dark){ .mega .card{background:rgba(255,255,255,.06)} }
+    .menu-toggle{width:40px;height:40px;border-radius:12px;border:1px solid var(--line);background:transparent;position:relative;display:none}
+    .menu-toggle::before,.menu-toggle::after{content:"";position:absolute;left:10px;right:10px;height:2px;background:currentColor;transition:.25s var(--ease)}
+    .menu-toggle::before{top:14px}.menu-toggle::after{bottom:14px}
+    .menu-toggle[aria-expanded="true"]::before{transform:translateY(6px) rotate(45deg)}
+    .menu-toggle[aria-expanded="true"]::after{transform:translateY(-6px) rotate(-45deg)}
 
-.mega .list{list-style:none; margin:0; padding:0; display:grid; gap:6px}
-.mega .list li a{
-  display:grid; grid-template-columns:1fr auto; align-items:center; gap:10px;
-  padding:8px 10px; border-radius:10px; color:inherit; text-decoration:none;
-}
-.mega .list li a:hover{background:rgba(0,0,0,.04); text-decoration:none}
-@media (prefers-color-scheme:dark){ .mega .list li a:hover{background:rgba(255,255,255,.06)} }
-.mega .list li a::after{
-  content:""; width:7px; height:7px; border:2px solid currentColor; border-top:0; border-left:0;
-  transform:rotate(-45deg); opacity:.45; transition:transform .16s ease, opacity .16s ease;
-}
-.mega .list li a:hover::after{opacity:.9; transform:translateX(2px) rotate(-45deg)}
+    .mega{position:absolute;left:0;right:0;top:100%;pointer-events:none;transform:translateY(-8px);opacity:0;
+      transition:transform .24s var(--ease),opacity .24s var(--ease)}
+    .mega[data-state="open"]{pointer-events:auto;transform:translateY(0);opacity:1}
+    .has-mega>.mega-toggle[aria-expanded="true"]+.mega{pointer-events:auto;transform:translateY(0);opacity:1}
+    .mega .mega__wrap{padding:12px 0 18px}
+    .mega .mega__grid-wrap{display:grid;grid-template-columns:1fr minmax(260px,320px);gap:16px;align-items:start}
+    .mega .mega__panels{max-height:var(--mega-h);overflow:hidden;transition:max-height .28s var(--ease)}
+    .mega__section{padding:4px 0 8px}
+    .mega__grid{display:grid;gap:12px;grid-template-columns:repeat(2,minmax(0,1fr))}
+    @media (min-width:860px){ .mega__grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+    @media (min-width:1100px){ .mega__grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
+    .mega .card{background:#fff;border:1px solid var(--line);border-radius:14px;padding:12px;box-shadow:0 6px 24px rgba(10,10,20,.08)}
+    @media (prefers-color-scheme:dark){ .mega .card{background:rgba(255,255,255,.06)}}
+    .mega__aside{display:grid;gap:10px}
+    .mega__aside .blog-card{display:grid;grid-template-columns:110px 1fr;gap:10px;border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
+    @media (prefers-color-scheme:dark){ .mega__aside .blog-card{background:rgba(255,255,255,.06)}}
+    .mega__aside img{width:110px;height:70px;object-fit:cover}
+    .mega__aside h4{font-size:.92rem;margin:8px 8px 6px}
+    .mega__aside p{font-size:.8rem;color:var(--ink-weak);margin:0 8px 8px}
 
-/* Cień paska przy aktywnym mega */
-.site-header[data-mega="open"]{box-shadow:0 10px 24px rgba(0,0,0,.08)}
+    .mobile-menu{position:fixed;inset:0;background:rgba(0,0,0,.4);backdrop-filter:blur(2px);z-index:80}
+    .mobile-menu[hidden]{display:none}
+    .mobile-menu__inner{position:absolute;top:0;right:0;bottom:0;box-sizing:border-box;width:min(420px,100vw);background:var(--bg);
+      border-left:1px solid var(--line);transform:translateX(100%);transition:transform .28s var(--ease);
+      display:grid;grid-template-rows:auto 1fr auto auto;gap:12px;padding:16px}
+    .mobile-menu[data-open="true"] .mobile-menu__inner{transform:translateX(0)}
+    .mobile-head{display:flex;align-items:center;justify-content:space-between}
+    .mobile-nav__list{list-style:none;margin:0;padding:0;display:grid;gap:6px}
+    .mobile-nav__list li a,.mobile-nav__list li button{
+      display:flex;align-items:center;justify-content:space-between;gap:10px;padding:12px 14px;border-radius:12px;border:1px solid var(--line);
+      background:#fff;color:inherit;text-decoration:none}
+    @media (prefers-color-scheme:dark){ .mobile-nav__list li a,.mobile-nav__list li button{background:rgba(255,255,255,.06)}}
+    .mobile-cta{margin-top:6px}
 
-/* Mobile: mega wyłączony, używamy drawer */
-@media (max-width:980px){ #mega{display:none !important} }
-
-/* ================= DRAWER MOBILE (#mobileMenu) ================= */
-#mobileMenu.mobile-menu,
-.mobile-menu{position:fixed; inset:0; background:rgba(0,0,0,.4); backdrop-filter:blur(2px); z-index:80}
-.mobile-menu[hidden]{display:none}
-#mobileMenu .mobile-menu__inner,
-.mobile-menu__inner{
-  position:absolute; top:0; right:0; bottom:0; width:min(420px,92vw);
-  background:var(--bg); border-left:1px solid var(--line); transform:translateX(100%);
-  transition:transform .28s var(--mega-ease);
-  display:grid; grid-template-rows:1fr auto auto; gap:12px; padding:16px;
-}
-#mobileMenu[data-open="true"] .mobile-menu__inner,
-.mobile-menu[data-open="true"] .mobile-menu__inner{transform:translateX(0)}
-#mobileList.mobile-nav__list,
-.mobile-nav__list{list-style:none; margin:0; padding:0; display:grid; gap:6px}
-.mobile-nav__list li a,
-.mobile-nav__list li button{
-  display:flex; align-items:center; justify-content:space-between; gap:10px;
-  padding:12px 14px; border-radius:12px; border:1px solid var(--line); background:#fff; color:inherit;
-}
-@media (prefers-color-scheme:dark){
-  .mobile-nav__list li a, .mobile-nav__list li button{background:rgba(255,255,255,.06)}
-}
-
-/* ================= HERO / CARDS / GRIDS ================= */
+    .dock{position:fixed;z-index:70;left:0;right:0;bottom:0;display:none;background:var(--bg);border-top:1px solid var(--line)}
+    .dock ul{list-style:none;margin:0;padding:6px 10px;display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
+    .dock a{display:flex;flex-direction:column;gap:4px;align-items:center;justify-content:center;padding:8px;border-radius:12px}
+    .dock svg{width:22px;height:22px}.dock span{font-size:.72rem}
+    @media (max-width:980px){ .nav{display:none}.menu-toggle{display:inline-block}.dock{display:block}}
+  /* ================= HERO / CARDS / GRIDS ================= */
 .section--hero{padding-top:32px;min-height:40vh}
 .hero__wrap{display:grid; gap:16px; align-items:center}
 @media (min-width:1024px){ .hero__wrap{grid-template-columns:1.1fr .9fr; gap:24px} }
@@ -343,92 +314,3 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .footer .col{background:rgba(255,255,255,.92); border:1px solid var(--line); border-radius:14px; padding:12px}
 @media (prefers-color-scheme:dark){ .footer .col{background:rgba(255,255,255,.06)} }
 @media (min-width:900px){ .footer-grid{grid-template-columns:1.2fr 1fr 1fr 1fr} }
-/* === Mega menu (kolumny, bez migotania) === */
-.nav-list{display:flex;gap:14px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
-.has-mega{position:relative;display:inline-flex;align-items:center}
-.has-mega>.mega-toggle{margin-left:-4px}
-.mega-toggle{background:none;border:0;padding:8px 10px;border-radius:8px;cursor:pointer}
-.mega,
-.mega-panel{
-  position:absolute;
-  left:0;
-  top:100%;
-  width:100%;
-  background:#fff;
-  box-shadow:0 10px 30px rgba(0,0,0,.08);
-  border:1px solid #e5e7eb;
-  border-radius:16px;
-  padding:20px;
-  pointer-events:none;
-  z-index:1000;
-}
-.mega:not([hidden]),
-.mega-panel:not([hidden]){pointer-events:auto;}
-.mega[hidden],
-.mega-panel[hidden]{display:none!important;}
-.mega-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:20px}
-.mega-col ul{list-style:none;margin:0;padding:0}
-@media(max-width:960px){
-  .mega{position:static;transform:none;width:auto}
-  .mega-grid{grid-template-columns:1fr}
-}
-
-/* === Minimal header layout === */
-.site-header{
-  position:sticky;
-  top:0;
-  background:#fff;
-  border-bottom:1px solid #e5e7eb;
-  z-index:1100;
-  transition:padding .2s ease;
-}
-.site-header.is-shrunk .bar{padding-block:4px;}
-.site-header .bar{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  max-width:1200px;
-  margin:0 auto;
-  padding:12px 20px;
-  gap:16px;
-}
-.site-header .actions{display:flex;align-items:center;gap:16px;}
-.site-header .btn-cta{
-  background:#0ea5e9;
-  color:#fff;
-  border-radius:999px;
-  padding:8px 18px;
-  font-weight:600;
-}
-.site-header .hamburger{
-  display:none;
-  width:40px;
-  height:40px;
-  border:1px solid #e5e7eb;
-  border-radius:8px;
-  background:transparent;
-}
-@media(max-width:980px){
-  .site-header nav{display:none;}
-  .site-header .hamburger{display:block;}
-}
-#mobile-nav{
-  position:fixed;
-  inset:0;
-  background:#fff;
-  overflow-y:auto;
-  z-index:999;
-}
-#mobile-nav[hidden]{display:none;}
-#mobile-nav ul{list-style:none;margin:0;padding:20px;display:grid;gap:12px;}
-.mobile-acc{
-  display:block;
-  width:100%;
-  text-align:left;
-  background:none;
-  border:0;
-  padding:12px;
-  border-radius:8px;
-  border:1px solid #e5e7eb;
-}
-.mobile-sub{list-style:none;margin:0;padding-left:16px;display:grid;gap:8px;}

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -12,121 +12,13 @@
 
   <!-- ============== CRITICAL CSS (scoped do #site-header) ============== -->
   <style>
-    #site-header{--bg:rgba(255,255,255,.82);--ink:#0b1020;--ink-weak:#64748b;--line:rgba(0,0,0,.08);
-      --brand:#0ea5e9;--ease:cubic-bezier(.2,.7,.2,1);--mega-h:0px;--fs-header:clamp(.75rem,2.2vw,1rem)}
-    @media (prefers-color-scheme:dark){
-      #site-header{--bg:rgba(15,23,42,.62);--ink:#e5e7eb;--ink-weak:#94a3b8;--line:rgba(255,255,255,.10)}
-    }
-    #site-header{position:sticky;top:0;z-index:60;background:var(--bg);
-      -webkit-backdrop-filter:saturate(180%) blur(12px);backdrop-filter:saturate(180%) blur(12px);
-      border-bottom:1px solid var(--line);transition:box-shadow .25s ease, background .25s ease}
-    #site-header.s--shadow{box-shadow:0 8px 22px rgba(0,0,0,.08)}
+    #site-header{--bg:rgba(255,255,255,.82);--ink:#0b1020;--ink-weak:#64748b;--line:rgba(0,0,0,.08);--brand:#0ea5e9;--ease:cubic-bezier(.2,.7,.2,1);--mega-h:0px;--fs-header:clamp(.75rem,2.2vw,1rem);position:sticky;top:0;z-index:60;background:var(--bg);-webkit-backdrop-filter:saturate(180%) blur(12px);backdrop-filter:saturate(180%) blur(12px);border-bottom:1px solid var(--line)}
     #site-header .wrap{max-width:980px;margin:0 auto;padding:0 12px 0 8px}
-    @media (min-width:768px){ #site-header .wrap{padding:0 18px 0 12px} }
-
+    @media (min-width:768px){ #site-header .wrap{padding:0 18px 0 12px}}
     .bar{display:grid;grid-template-columns:minmax(120px,170px) 1fr auto;gap:10px;justify-items:center;align-items:center;padding:6px 0}
     #site-header a{color:inherit;text-decoration:none}
     .brand{display:inline-flex;align-items:center;gap:10px}
-    .brand__logo{height:auto;width:clamp(90px,24vw,160px);transition:transform .18s ease,filter .18s ease}
-    .brand:hover .brand__logo{transform:scale(1.045);filter:drop-shadow(0 6px 18px rgba(14,165,233,.28))}
-
-    .nav__list{list-style:none;margin:0;padding:0;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
-    .nav__list>li{position:relative}
-    .nav__list>li>a,.nav__list>li>button{appearance:none;background:transparent;border:0;color:inherit;font:inherit;line-height:1;cursor:pointer;
-      padding:8px 10px;border-radius:12px;display:inline-flex;align-items:center;gap:6px;white-space:nowrap;font-size:var(--fs-header)}
-    .nav__list>li:hover>a{background:rgba(0,0,0,.04)}
-    @media (prefers-color-scheme:dark){ .nav__list>li:hover>a{background:rgba(255,255,255,.06)}}
-
-    .actions{display:flex;align-items:center;gap:10px}
-    .btn{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:14px;border:1px solid var(--line);
-      background:#fff;font-weight:700;font-size:var(--fs-header);color:var(--ink);transition:transform .15s ease, background .2s ease}
-    .btn:hover{transform:translateY(-1px)}
-    @media (prefers-color-scheme:dark){ .btn{background:rgba(255,255,255,.06)}}
-    .btn-primary{background:var(--brand);border-color:transparent;color:#fff}
-
-    .langs{position:relative}
-    .lang-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:12px;border:1px solid var(--line);background:#fff}
-    @media (prefers-color-scheme:dark){ .lang-btn{background:rgba(255,255,255,.06)}}
-    .flag{width:18px;height:12px;border-radius:3px;border:1px solid var(--line);object-fit:cover}
-    .chev{width:14px;height:14px;opacity:.7}
-    .lang-dd{position:absolute;right:0;top:100%;margin-top:8px;min-width:180px;background:var(--bg);
-      border:1px solid var(--line);border-radius:12px;box-shadow:0 12px 28px rgba(10,10,20,.12);padding:6px;display:none}
-    .lang-dd[aria-hidden="false"]{display:block}
-    .lang-dd a{display:flex;align-items:center;gap:8px;padding:8px;border-radius:10px}
-    .lang-dd a[aria-current="true"]{outline:2px solid var(--line)}
-    .lang-dd a:hover{background:rgba(0,0,0,.04)}
-    @media (prefers-color-scheme:dark){ .lang-dd a:hover{background:rgba(255,255,255,.06)}}
-
-    .theme{position:relative}
-    .theme-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:12px;border:1px solid rgba(255,255,255,.18);background:#fff}
-    @media (prefers-color-scheme:dark){ .theme-btn{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.28)}}
-    .theme-btn img{width:16px;height:16px}
-    .theme-dd{position:absolute;right:0;top:100%;margin-top:8px;min-width:160px;background:var(--bg);
-      border:1px solid var(--line);border-radius:12px;box-shadow:0 12px 28px rgba(10,10,20,.12);padding:6px;display:none}
-    .theme-dd[aria-hidden="false"]{display:block}
-    .theme-dd button{width:100%;text-align:left;padding:8px;border:0;background:transparent;border-radius:10px;display:flex;gap:8px;align-items:center}
-    .theme-dd button:hover{background:rgba(0,0,0,.04)}
-    @media (prefers-color-scheme:dark){ .theme-dd button:hover{background:rgba(255,255,255,.06)}}
-
-    .social{display:flex;gap:8px;margin-left:6px}
-    .social a{display:inline-flex;padding:8px;border-radius:50%}
-    .status-pill{margin-left:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--line);
-      font-weight:600;font-size:var(--fs-header);color:var(--ink-weak);background:rgba(14,165,233,.08)}
-
-    @media (max-width:600px){
-      .bar{grid-template-columns:auto 1fr}
-      .bar>*{min-width:0}
-      .actions{flex-wrap:wrap}
-      .actions>*{flex:1 1 auto;min-width:0}
-      .btn{max-width:100%;box-sizing:border-box;padding:6px 8px;font-size:var(--fs-header)}
-      .social,.status-pill{display:none}
-    }
-
-    .menu-toggle{width:40px;height:40px;border-radius:12px;border:1px solid var(--line);background:transparent;position:relative;display:none}
-    .menu-toggle::before,.menu-toggle::after{content:"";position:absolute;left:10px;right:10px;height:2px;background:currentColor;transition:.25s var(--ease)}
-    .menu-toggle::before{top:14px}.menu-toggle::after{bottom:14px}
-    .menu-toggle[aria-expanded="true"]::before{transform:translateY(6px) rotate(45deg)}
-    .menu-toggle[aria-expanded="true"]::after{transform:translateY(-6px) rotate(-45deg)}
-
-    .mega{position:absolute;left:0;right:0;top:100%;pointer-events:none;transform:translateY(-8px);opacity:0;
-      transition:transform .24s var(--ease),opacity .24s var(--ease)}
-    .mega[data-state="open"]{pointer-events:auto;transform:translateY(0);opacity:1}
-    .has-mega>.mega-toggle[aria-expanded="true"]+.mega{pointer-events:auto;transform:translateY(0);opacity:1}
-    .mega .mega__wrap{padding:12px 0 18px}
-    .mega .mega__grid-wrap{display:grid;grid-template-columns:1fr minmax(260px,320px);gap:16px;align-items:start}
-    .mega .mega__panels{max-height:var(--mega-h);overflow:hidden;transition:max-height .28s var(--ease)}
-    .mega__section{padding:4px 0 8px}
-    .mega__grid{display:grid;gap:12px;grid-template-columns:repeat(2,minmax(0,1fr))}
-    @media (min-width:860px){ .mega__grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
-    @media (min-width:1100px){ .mega__grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
-    .mega .card{background:#fff;border:1px solid var(--line);border-radius:14px;padding:12px;box-shadow:0 6px 24px rgba(10,10,20,.08)}
-    @media (prefers-color-scheme:dark){ .mega .card{background:rgba(255,255,255,.06)}}
-    .mega__aside{display:grid;gap:10px}
-    .mega__aside .blog-card{display:grid;grid-template-columns:110px 1fr;gap:10px;border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
-    @media (prefers-color-scheme:dark){ .mega__aside .blog-card{background:rgba(255,255,255,.06)}}
-    .mega__aside img{width:110px;height:70px;object-fit:cover}
-    .mega__aside h4{font-size:.92rem;margin:8px 8px 6px}
-    .mega__aside p{font-size:.8rem;color:var(--ink-weak);margin:0 8px 8px}
-
-    .mobile-menu{position:fixed;inset:0;background:rgba(0,0,0,.4);backdrop-filter:blur(2px);z-index:80}
-    .mobile-menu[hidden]{display:none}
-    .mobile-menu__inner{position:absolute;top:0;right:0;bottom:0;box-sizing:border-box;width:min(420px,100vw);background:var(--bg);
-      border-left:1px solid var(--line);transform:translateX(100%);transition:transform .28s var(--ease);
-      display:grid;grid-template-rows:auto 1fr auto auto;gap:12px;padding:16px}
-    .mobile-menu[data-open="true"] .mobile-menu__inner{transform:translateX(0)}
-    .mobile-head{display:flex;align-items:center;justify-content:space-between}
-    .mobile-nav__list{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-    .mobile-nav__list li a,.mobile-nav__list li button{
-      display:flex;align-items:center;justify-content:space-between;gap:10px;padding:12px 14px;border-radius:12px;border:1px solid var(--line);
-      background:#fff;color:inherit;text-decoration:none}
-    @media (prefers-color-scheme:dark){ .mobile-nav__list li a,.mobile-nav__list li button{background:rgba(255,255,255,.06)}}
-    .mobile-cta{margin-top:6px}
-
-    .dock{position:fixed;z-index:70;left:0;right:0;bottom:0;display:none;background:var(--bg);border-top:1px solid var(--line)}
-    .dock ul{list-style:none;margin:0;padding:6px 10px;display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
-    .dock a{display:flex;flex-direction:column;gap:4px;align-items:center;justify-content:center;padding:8px;border-radius:12px}
-    .dock svg{width:22px;height:22px}.dock span{font-size:.72rem}
-    @media (max-width:980px){ .nav{display:none}.menu-toggle{display:inline-block}.dock{display:block}}
+    .brand__logo{height:auto;width:clamp(90px,24vw,160px)}
   </style>
 
   <div id="promoBar" class="promo-bar" hidden>


### PR DESCRIPTION
## Summary
- extract header and navigation CSS into shared `assets/css/site.css`
- keep only minimal critical header styles inline in `_partials/header.html`

## Testing
- `python tools/build.py`
- `pytest` *(fails: BrowserType.launch executable doesn't exist; `playwright install` 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ace603869c833389ec648f5758abde