### PR TITLE
feat: add deferred menu script and move header styles

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -434,23 +434,25 @@ body[data-csr="true"] [aria-busy="true"]{ display:none }
 .mobile-sub{list-style:none;margin:0;padding-left:16px;display:grid;gap:8px;}
 
 /* === Simple header + mega menu === */
-.site-header .nav{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:16px;
-  padding:12px 20px;
-}
-.site-header .primary{flex:1;}
-#navList{list-style:none;margin:0;padding:0;display:flex;gap:12px;align-items:center;}
-.has-mega{position:relative;display:flex;align-items:center;}
-.mega-toggle{background:none;border:0;padding:0 6px;cursor:pointer;}
-.mega{position:absolute;left:0;top:100%;width:100%;background:var(--bg,#fff);border:1px solid var(--line,#e5e7eb);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.08);padding:20px;pointer-events:none;z-index:1000;}
-.mega[hidden]{display:none;}
-.has-mega>.mega-toggle[aria-expanded="true"]+.mega{pointer-events:auto;}
+.site-header{position:sticky;top:0;z-index:50;backdrop-filter:saturate(180%) blur(14px);
+  background:color-mix(in srgb, var(--surface, #fff) 80%, transparent); border-bottom:1px solid #0001}
+.site-header .nav{display:flex;align-items:center;gap:16px;min-height:64px}
+.site-header .brand{display:inline-flex;align-items:center;gap:8px}
+.primary ul{display:flex;gap:12px;list-style:none;margin:0;padding:0}
+.primary a.toplink{padding:10px 12px;border-radius:8px;color:var(--fg,#111);text-decoration:none}
+.primary a.toplink.active{background:#0000;box-shadow:inset 0 -2px 0 var(--brand,#0ea5e9)}
+.has-mega{position:relative}
+.mega-toggle{margin-left:4px;border:0;background:transparent;cursor:pointer}
+.mega{position:absolute;left:0;right:0;top:100%;background:color-mix(in srgb, #fff 96%, transparent);
+  border:1px solid #0001;border-radius:12px;padding:16px;box-shadow:0 10px 30px #0002}
 .mega .wrap{display:grid;gap:12px;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));}
 .mega-item{display:block;padding:6px 8px;border-radius:8px;color:inherit;text-decoration:none;}
 .mega-item:hover{background:rgba(0,0,0,.04);text-decoration:none;}
+@media (prefers-color-scheme: dark){
+  .site-header{background:rgba(15,23,42,.7);border-color:#fff1}
+  .primary a.toplink{color:#e5e7eb}
+  .mega{background:rgba(30,41,59,.96);border-color:#fff1}
+}
 @media(max-width:960px){
   .site-header .primary{display:none;}
 }

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,0 +1,51 @@
+(function(){
+  function closeAll(exceptId){
+    document.querySelectorAll('.mega').forEach(m=>{
+      if (!exceptId || m.id !== exceptId){
+        m.hidden = true; m.setAttribute('aria-hidden','true');
+        const btn = document.querySelector('.mega-toggle[aria-controls="'+m.id+'"]');
+        if (btn) btn.setAttribute('aria-expanded','false');
+      }
+    });
+  }
+
+  function init(){
+    const nav = document.querySelector('[data-nav]'); if (!nav) return;
+
+    nav.addEventListener('click', (e)=>{
+      const btn = e.target.closest('.mega-toggle');
+      if(!btn) return;
+      e.preventDefault();
+      const id = btn.getAttribute('aria-controls');
+      const panel = document.getElementById(id);
+      const willOpen = panel.hidden;
+      closeAll(id);
+      panel.hidden = !willOpen;
+      panel.setAttribute('aria-hidden', String(!willOpen));
+      btn.setAttribute('aria-expanded', String(willOpen));
+      if (willOpen) panel.querySelector('a,button,input,select,textarea')?.focus({preventScroll:true});
+    });
+
+    document.addEventListener('keydown',(e)=>{
+      if(e.key==='Escape'){ closeAll(); document.querySelector('.mega-toggle[aria-expanded="true"]')?.focus(); }
+    });
+
+    document.addEventListener('click',(e)=>{
+      if (!e.target.closest('.has-mega')) closeAll();
+    });
+
+    // Rozpoznaj aktywny język → oznacz aktywną ścieżkę
+    try{
+      const lang = document.documentElement.lang || 'pl';
+      const here = location.pathname.replace(/\/+$/,'');
+      document.querySelectorAll('#navList a.toplink').forEach(a=>{
+        const p=a.getAttribute('href').replace(/\/+$/,'');
+        if (p===here) a.classList.add('active');
+      });
+    }catch(_){ }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, {once:true});
+  } else { init(); }
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -137,8 +137,7 @@
     .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden}
     .skip-link:focus{left:12px;top:8px;width:auto;height:auto;background:#111;color:#fff;padding:8px 12px;border-radius:12px;z-index:100}
     :focus-visible{outline:3px solid var(--focus);outline-offset:2px}
-    .site-header{position:sticky;top:0;z-index:50;backdrop-filter:saturate(180%) blur(12px);background:rgba(255,255,255,.72);border-bottom:1px solid rgba(0,0,0,.06)}
-    @media (prefers-color-scheme: dark){body{background:#0b1020;color:#e5e7eb}.site-header{background:rgba(15,23,42,.62);border-color:rgba(255,255,255,.08)}}
+    @media (prefers-color-scheme: dark){body{background:#0b1020;color:#e5e7eb}}
   </style>
 
   <script>document.documentElement.classList.remove('no-js');</script>
@@ -159,6 +158,8 @@
 
   {# --- JSON-LD (builder wstrzykuje gotowy <script type="application/ld+json">) --- #}
   {% if jsonld %}{{ jsonld|safe }}{% endif %}
+
+  <script defer src="/assets/js/menu.js"></script>
 
   {# --- JS (defer) z pages.yml / buildera --- #}
   {% if assets.js %}


### PR DESCRIPTION
## Summary
- add deferred `menu.js` for mega menu interactions
- consolidate header and menu styles in `assets/css/site.css`
- load new script from base template and drop inline header CSS

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8cc7e3208333bb863e6165c35f8a