### PR TITLE
ci: fetch CMS via curl and link site css

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,56 +61,58 @@ jobs:
       #   source .venv/bin/activate
       #   pytest -q -k 'not dropdown_keyboard'
 
-      - name: Provide CMS from runner
+      - name: Provide CMS
         run: |
           set -e
           mkdir -p data/cms
           SRC="${{ vars.CMS_SOURCE }}"
-          [ -z "$SRC" ] && SRC="${{ vars.LOCAL_XLSX }}"   # opcjonalny fallback; jeśli nie używasz, usuń tę linię
-          [ -z "$SRC" ] && SRC="/Users/illia/Desktop/Kras_transStrona/CMS.xlsx"
-          SRC="$(echo "$SRC" | sed 's/[[:space:]\.]*$//')"   # obetnij spacje/kropki z końca
+          SRC="$(echo "$SRC" | sed 's/[[:space:]\.]*$//')"
           echo "CMS_SOURCE_PATH: $SRC"
-          if [ -f "$SRC" ]; then
-            cp "$SRC" data/cms/menu.xlsx
-          else
-            echo "⚠️ CMS not found at: $SRC; creating empty placeholder"
-            touch data/cms/menu.xlsx
-          fi
-          echo "CMS_SHA256: $(shasum -a 256 data/cms/menu.xlsx | awk '{print $1}' || true)"
-            ls -lah data/cms
-
-        - name: Configure Pages
-          uses: actions/configure-pages@v5
-
-        - name: CMS Schema Guard
-          run: |
-            set -e
-            source .venv/bin/activate
-            python tools/cms_guard.py .codex/cms_schema.yml data/cms/menu.xlsx
-
-        - name: Generate CMS contract
-          run: |
-            source .venv/bin/activate
-            python tools/explain_cms.py
-
-        - name: Commit CMS contract (if changed)
-          run: |
-            if ! git diff --quiet -- docs/CMS-CONTRACT.md; then
-              git config user.email "bot@kras-trans.com"
-              git config user.name "KT Bot"
-              git add docs/CMS-CONTRACT.md
-              git commit -m "docs: refresh CMS contract"
+          if [ -n "$SRC" ]; then
+            if [[ "$SRC" =~ ^https:// ]]; then
+              echo "Downloading CMS from $SRC"
+              curl -fsSL "$SRC" -o data/cms/menu.xlsx
+            else
+              echo "Copying CMS from $SRC"
+              cp "$SRC" data/cms/menu.xlsx
             fi
+          fi
+          test -f data/cms/menu.xlsx
+          echo "CMS_SHA256: $(shasum -a 256 data/cms/menu.xlsx | awk '{print $1}')"
+          ls -lah data/cms
 
-        - name: Upload CMS sheet report
-          if: ${{ always() }}
-          uses: actions/upload-artifact@v4
-          with:
-            name: cms-sheets
-            path: |
-              sheet_report.json
-              data/cms/menu.xlsx
-            if-no-files-found: warn
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: CMS Schema Guard
+        run: |
+          set -e
+          source .venv/bin/activate
+          python tools/cms_guard.py .codex/cms_schema.yml data/cms/menu.xlsx
+
+      - name: Generate CMS contract
+        run: |
+          source .venv/bin/activate
+          python tools/explain_cms.py
+
+      - name: Commit CMS contract (if changed)
+        run: |
+          if ! git diff --quiet -- docs/CMS-CONTRACT.md; then
+            git config user.email "bot@kras-trans.com"
+            git config user.name "KT Bot"
+            git add docs/CMS-CONTRACT.md
+            git commit -m "docs: refresh CMS contract"
+          fi
+
+      - name: Upload CMS sheet report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cms-sheets
+          path: |
+            sheet_report.json
+            data/cms/menu.xlsx
+          if-no-files-found: warn
 
       - name: Build
         env:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ CMS data and writes the generated site to the `dist/` directory.
 Menu labels must be unique within each language. During the build process,
 duplicate labels trigger a warning and the later entries are ignored.
 
-If `data/cms/menu.xlsx` is missing, the build script tries to fetch the sheet
-from the location specified by the `CMS_SOURCE` environment variable. The value
-may point to a local file path or an HTTP(S) URL. The downloaded file is cached
-under `data/cms/menu.xlsx` for subsequent runs.
+If `data/cms/menu.xlsx` is missing, the build script looks for the sheet at the
+location specified by the `CMS_SOURCE` environment variable. The value may point
+to a local file path or an HTTPS URL. The file is saved as
+`data/cms/menu.xlsx` before the build proceeds.
+
+## Skąd brać CMS
+
+1. **A:** commit deterministic `data/cms/menu.xlsx` into the repo.
+2. **B:** set `vars.CMS_SOURCE=https://…/CMS.xlsx` so the workflow fetches it via `curl`.
+3. **C:** (optional) obtain the sheet from a GitHub Release asset via the API.
 
 ## Navigation menu
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,6 +123,7 @@
       <link rel="stylesheet" href="{{ href }}" />
     {% endfor %}
   {% endif %}
+  <link rel="stylesheet" href="/assets/css/site.css" />
 
   {# --- Self-host fonts + minimum krytycznego CSS (a11y + layout) --- #}
   <link rel="preload" as="font" type="font/woff2" href="/assets/fonts/InterVariable.woff2" crossorigin>


### PR DESCRIPTION
## Summary
- download CMS via `curl` or local path and fail build if missing
- include `/assets/css/site.css` in base template
- document CMS sourcing options

## Testing
- `python tools/cms_guard.py .codex/cms_schema.yml data/cms/menu.xlsx | tail -n 20`
- `CLEAN=1 MINIFY=1 python tools/build.py`
- `test -f dist/_routes.json && cp dist/_routes.json _routes.json || true`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad92b5c08c8333a334edb1364564d6