### PR TITLE
ci: purge local/gsheet sources, repo-only CMS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.xlsx  binary -text -diff
+*.xls   binary -text -diff
+*.zip   binary -text -diff
+*.pdf   binary -text -diff
+*.woff2 binary -text -diff

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -f data/cms/menu.xlsx ]; then
-            echo "::error file=data/cms/menu.xlsx::Brak pliku CMS. Wgraj data/cms/menu.xlsx i uruchom ponownie."
+            echo "::error file=data/cms/menu.xlsx::Brak pliku CMS w repo. Wgraj data/cms/menu.xlsx i uruchom ponownie."
             exit 1
           fi
           ls -lh data/cms/menu.xlsx

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and exits with an error if the file is missing.
 
 ## Skąd brać CMS
 
-Commit deterministic `data/cms/menu.xlsx` into the repo.
+Źródło CMS: jedynie `data/cms/menu.xlsx` w repo. Aktualizacje arkusza wgrywa użytkownik ręcznie (upload) lub commit. PR nie zawiera `menu.xlsx`.
 
 ## Navigation menu
 

--- a/pages.yml
+++ b/pages.yml
@@ -505,8 +505,8 @@ security:
     default-src: ["'self'"]
     img-src:     ["'self'","data:","https:"]
     style-src:   ["'self'","'unsafe-inline'"]
-    script-src:  ["'self'","https://script.google.com"]
-    connect-src: ["'self'","https://script.google.com"]
+    script-src:  ["'self'"]
+    connect-src: ["'self'"]
 
 a11y:
   require_alt: true

--- a/tools/build.py
+++ b/tools/build.py
@@ -17,7 +17,7 @@ NAJWAŻNIEJSZE FUNKCJE:
 - Root "/" = redirect do /{defaultLang}/ + GSC meta + canonical
 - City×Service generator + thin/noindex + OG-image (opcjonalnie)
 - Sitemapy z alternates (xhtml:link), news-sitemap (okno godz.), robots.txt
-- Redirect stubs, BingSiteAuth.xml, {INDEXNOW_KEY}.txt, /admin/indexing.html (Apps Script dispatch)
+  - Redirect stubs, BingSiteAuth.xml, {INDEXNOW_KEY}.txt, /admin/indexing.html
 - On-site search index (per lang), RSS/Atom, link-checker, raporty
 
 WYMAGANE PAKIETY:
@@ -516,7 +516,7 @@ def render_template(name: str, ctx: Dict[str, Any]) -> str:
 # Globalne dane dostępne w szablonach
 env.globals.update({
   "site": CFG.get("site", {}),
-  "cms_endpoint": "",  # Apps Script wyłączony
+  "cms_endpoint": "",
   "ga_id": GA_ID,
   "gsc_verification": GSC,
   "assets": CFG.get("assets", {})
@@ -974,10 +974,10 @@ def build_all():
         except Exception as e:
             print(f"[nav.yml] read error: {e}", file=sys.stderr)
     nav_by_lang = nav_fallback
-cms = CMS
+    cms = CMS
     print(cms.get("report", "[cms] no report"))
 
-CMS.setdefault("blog", cms.get("blog_rows", []))
+    CMS.setdefault("blog", cms.get("blog_rows", []))
     CMS.setdefault("routes", cms.get("routes") or cms.get("page_routes") or {})
     CMS.setdefault("strings", cms.get("strings", []))
     nav_rows = cms.get("nav") or cms.get("menu_rows") or []

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -1,21 +1,14 @@
 # tools/cms_ingest.py
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, Any, List, Optional
-import os
+from typing import Dict, Any, List
 import re
-import shutil
 import hashlib
 
-try:
-    import requests
-except Exception:  # pragma: no cover - requests may be missing in minimal envs
-    requests = None
-
-DATA = Path("data/cms")
-DATA.mkdir(parents=True, exist_ok=True)
-CACHE_XLSX = DATA / "menu.xlsx"
-SHA_FILE = DATA / ".cms_sha"
+CMS_DIR = Path("data/cms")
+CMS_DIR.mkdir(parents=True, exist_ok=True)
+XLSX = CMS_DIR / "menu.xlsx"
+SHA_FILE = CMS_DIR / ".cms_sha"
 
 
 def _sha256(p: Path) -> str:
@@ -24,26 +17,14 @@ def _sha256(p: Path) -> str:
     return h.hexdigest()
 
 
-def fetch_xlsx() -> tuple[Path, str]:
-    """Fetch CMS XLSX (URL or local path) and cache it."""
-    src = os.getenv("CMS_SOURCE") or str(CACHE_XLSX)
-    p = CACHE_XLSX
-    if re.match(r"https?://", src):
-        if not requests:
-            raise RuntimeError("requests not available")
-        r = requests.get(src, timeout=30)
-        r.raise_for_status()
-        p.write_bytes(r.content)
-    else:
-        p_src = Path(src)
-        if not p_src.exists():
-            raise FileNotFoundError(f"CMS not found: {src}")
-        if p_src.resolve() != p.resolve():
-            p.write_bytes(p_src.read_bytes())
-    sha = _sha256(p)
+def ensure_xlsx() -> tuple[Path, str]:
+    """Return repo-provided CMS XLSX and its SHA."""
+    if not XLSX.exists():
+        raise SystemExit("Missing data/cms/menu.xlsx (repo-only)")
+    sha = _sha256(XLSX)
     SHA_FILE.write_text(sha)
-    print(f"[cms] source={src} -> {p} sha={sha}")
-    return p, sha
+    print(f"[cms] source=repo -> {XLSX} sha={sha}")
+    return XLSX, sha
 
 
 def normalize_segment(s: str) -> str:
@@ -215,7 +196,7 @@ def _find_sheet(sheets, group):
             pass
     return best if best_score >= 3 else None
 
-def load_all(cms_root: Path, explicit_src: Optional[Path] = None) -> Dict[str, Any]:
+def load_all(cms_root: Path) -> Dict[str, Any]:
     """Wczytuje wszystkie arkusze XLSX i klasyfikuje je podobnie jak ``cms_guard``.
 
     Wynik łączy dane z wielu arkuszy (union) i zwraca słownik zawierający
@@ -225,35 +206,7 @@ def load_all(cms_root: Path, explicit_src: Optional[Path] = None) -> Dict[str, A
     cms_root = _log_path(cms_root)
     report: List[str] = []
 
-    # wybór źródła
-    try:
-        if explicit_src and explicit_src.exists():
-            cms_root.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(explicit_src, CACHE_XLSX)
-            src = CACHE_XLSX
-            sha = _sha256(src)
-            SHA_FILE.write_text(sha)
-            print(f"[cms] source={explicit_src} -> {src} sha={sha}")
-        else:
-            src, sha = fetch_xlsx()
-    except Exception as e:
-        report.append(f"[cms_ingest] warn: fetch failed: {e}")
-        return {
-            "pages_rows": [],
-            "page_routes": {},
-            "routes": {},
-            "menu_rows": [],
-            "page_meta": {},
-            "blocks": {},
-            "blog_rows": [],
-            "strings": [],
-            "media": [],
-            "company": [],
-            "redirects": [],
-            "collections": {},
-            "report": "[cms] no source",
-        }
-
+    src, sha = ensure_xlsx()
     report.append(f"[cms_ingest] source: {src}")
     report.append(f"[cms_ingest] sha: {sha}")
 

--- a/tools/cms_snapshot.py
+++ b/tools/cms_snapshot.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Generate snapshot report for CMS XLSX file."""
 import json
-import os
 import sys
+from pathlib import Path
 from collections import Counter
 from typing import Any, Dict, List, Optional
 
@@ -21,12 +21,12 @@ def _truthy(value: Any) -> bool:
     return False
 
 def main(path: Optional[str] = None) -> None:
-    # Resolve path from argument or environment variable
     if path is None:
-        path = os.environ.get("CMS_SOURCE")
-    if not path:
-        print("Usage: python tools/cms_snapshot.py <xlsx_path>", file=sys.stderr)
-        sys.exit(1)
+        path = Path('data/cms/menu.xlsx')
+    else:
+        path = Path(path)
+    if not path.exists():
+        raise SystemExit("Missing data/cms/menu.xlsx (repo-only)")
 
     wb = load_workbook(path, read_only=True, data_only=True)
 


### PR DESCRIPTION
## Summary
- simplify CMS ingest to require `data/cms/menu.xlsx` in repo
- drop legacy Google Script/Sheet references
- document repo-only CMS source and binary file handling

Ingest numbers: langs=7, pages_rows=72, blocks_langs=0

## Testing
- `python tools/build.py`
- `pytest -q` *(fails: BrowserType.launch executable missing; title mismatch)*
- `gh workflow run pages.yml --ref work` *(fails: not logged into GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68adaa9bcb4883338a81e297bf353e80