### PR TITLE
Fix home page meta mapping and templates

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -116,6 +116,13 @@ jobs:
           set -e
           source .venv/bin/activate
           python tools/cms_verify_build.py
+      - name: Upload page debug
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: page-home-debug
+          path: _debug/page_home_pl.json
+          if-no-files-found: warn
       - name: Export routes diag
         if: ${{ always() }}
         run: |

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
 
   {# bezpieczny tytuł: preferuj seo_title, potem h1/title, w ostateczności brand #}
   <title>{{ page.seo_title or page.h1 or page.title or _og_title or _brand_name }}</title>
-  <meta name="description" content="{{ page.meta_desc or _meta_desc }}" />
+  <meta name="description" content="{{ page.meta_desc or _meta_desc }}">
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />
 
@@ -68,8 +68,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ _brand_name }}" />
   <meta property="og:url" content="{{ page.canonical or canonical }}" />
-  <meta property="og:title" content="{{ page.seo_title or page.title or _og_title or _brand_name }}" />
-  <meta property="og:description" content="{{ page.meta_desc or _meta_desc }}" />
+  <meta property="og:title" content="{{ page.seo_title or page.title or _og_title or _brand_name }}">
+  <meta property="og:description" content="{{ page.meta_desc or _meta_desc }}">
   <meta property="og:image" content="{{ (_site.get('url') or _site.get('base_url') or '') ~ (page.og_image or _og_image or '/assets/media/og-default.webp') }}" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ page.seo_title or page.title or _og_title or _brand_name }}" />

--- a/templates/page.html
+++ b/templates/page.html
@@ -132,6 +132,8 @@
 {# ================================================================
    1) SERVICES — kafle, reel na mobile
    ================================================================ #}
+{% set services = ssr.services if ssr and ssr.services else [] %}
+{% if services %}
 <section id="services" class="section section--altA" aria-labelledby="services-title"
         data-api="/home/services" aria-busy="false">
   <div class="wrap">
@@ -145,8 +147,7 @@
     </header>
 
     <div class="reel services__reel" role="list" aria-label="Usługi" data-bind="aria: { label: home.aria_services }">
-      {% if ssr and ssr.services %}
-        {% for s in ssr.services %}
+        {% for s in services %}
           {% set href = ssr.routes[s.slugKey][page.lang] if ssr.routes.get(s.slugKey) else '/' ~ (page.lang or 'pl') ~ '/' ~ s.slugKey ~ '/' %}
           <article class="card card--service" role="listitem" itemscope itemtype="https://schema.org/Service">
             <div class="card__icon" aria-hidden="true">{{ s.icon|safe }}</div>
@@ -155,28 +156,19 @@
             <a class="card__link" href="{{ href }}">{{ s.cta.label }}</a>
           </article>
         {% endfor %}
-      {% else %}
-        {# CSR placeholder: 8 slotów #}
-        {% for i in range(0,8) %}
-          <article class="card card--service" role="listitem">
-            <div class="card__icon" aria-hidden="true" data-bind="html: services[{{ i }}].icon">&#128663;</div>
-              <h3 class="card__title" data-bind="text: services[{{ i }}].title">{{ STR('service_title') }}</h3>
-              <p class="card__desc" data-bind="text: services[{{ i }}].desc">{{ STR('service_desc') }}</p>
-              <a class="card__link" data-bind="href: services[{{ i }}].slugKey|slug, text: services[{{ i }}].cta.label">{{ STR('service_cta') }}</a>
-          </article>
-        {% endfor %}
-      {% endif %}
     </div>
   </div>
   <div class="divider divider--wave"></div>
 </section>
+{% endif %}
 
 {# ================================================================
    2) INDUSTRIES — siatka 3/4 kolumny
    ================================================================ #}
 {% set industries = ssr.industries if ssr and ssr.industries else [] %}
+{% if industries %}
 <section id="industries" class="section section--altB" aria-labelledby="ind-title"
-        data-api="/home/industries" aria-busy="false"{% if not industries %} hidden{% endif %}>
+        data-api="/home/industries" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="ind-title">{{ ssr.home.section_titles.industries if ssr and ssr.home.section_titles.industries else '' }}</h2>
@@ -192,13 +184,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    3) COVERAGE — korytarze, mini map-widget (dekor)
    ================================================================ #}
 {% set coverage = ssr.coverage if ssr and ssr.coverage else [] %}
+{% if coverage %}
 <section id="coverage" class="section section--altC" aria-labelledby="cov-title"
-        data-api="/home/coverage" aria-busy="false"{% if not coverage %} hidden{% endif %}>
+        data-api="/home/coverage" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="cov-title">{{ ssr.home.section_titles.coverage if ssr and ssr.home.section_titles.coverage else '' }}</h2>
@@ -217,13 +211,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    4) PROCESS — timeline (ol > li)
    ================================================================ #}
 {% set process = ssr.process if ssr and ssr.process else [] %}
+{% if process %}
 <section id="process" class="section section--timeline" aria-labelledby="proc-title"
-        data-api="/home/process" aria-busy="false"{% if not process %} hidden{% endif %}>
+        data-api="/home/process" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="proc-title">{{ ssr.home.section_titles.process if ssr and ssr.home.section_titles.process else '' }}</h2>
@@ -236,13 +232,15 @@
     </ol>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    5) TRUST — KPI kafle
    ================================================================ #}
 {% set trust = ssr.trust if ssr and ssr.trust else [] %}
+{% if trust %}
 <section id="trust" class="section section--altD" aria-labelledby="trust-title"
-        data-api="/home/trust" aria-busy="false"{% if not trust %} hidden{% endif %}>
+        data-api="/home/trust" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="trust-title">{{ ssr.home.section_titles.trust if ssr and ssr.home.section_titles.trust else '' }}</h2>
@@ -259,13 +257,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    6) TESTIMONIALS — karuzela „reel”
    ================================================================ #}
 {% set testimonials = ssr.testimonials if ssr and ssr.testimonials else [] %}
+{% if testimonials %}
 <section id="testimonials" class="section section--altE" aria-labelledby="testi-title"
-        data-api="/home/testimonials" aria-busy="false"{% if not testimonials %} hidden{% endif %}>
+        data-api="/home/testimonials" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="testi-title">{{ ssr.home.section_titles.testimonials if ssr and ssr.home.section_titles.testimonials else '' }}</h2>
@@ -284,13 +284,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    7) PARTNERS — paski logo
    ================================================================ #}
 {% set partners = ssr.partners if ssr and ssr.partners else [] %}
+{% if partners %}
 <section id="partners" class="section section--altF" aria-labelledby="partners-title"
-        data-api="/home/partners" aria-busy="false"{% if not partners %} hidden{% endif %}>
+        data-api="/home/partners" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="partners-title">{{ ssr.home.section_titles.partners if ssr and ssr.home.section_titles.partners else '' }}</h2>
@@ -306,13 +308,15 @@
     </ul>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    8) FLEET — kafle
    ================================================================ #}
 {% set fleet = ssr.fleet if ssr and ssr.fleet else [] %}
+{% if fleet %}
 <section id="fleet" class="section section--altG" aria-labelledby="fleet-title"
-        data-api="/home/fleet" aria-busy="false"{% if not fleet %} hidden{% endif %}>
+        data-api="/home/fleet" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="fleet-title">{{ ssr.home.section_titles.fleet if ssr and ssr.home.section_titles.fleet else '' }}</h2>
@@ -328,13 +332,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    9) PRICING / QUOTE — kafle linkujące
    ================================================================ #}
 {% set pricing = ssr.pricing if ssr and ssr.pricing else [] %}
+{% if pricing %}
 <section id="pricing" class="section section--altH" aria-labelledby="pricing-title"
-        data-api="/home/pricing" aria-busy="false"{% if not pricing %} hidden{% endif %}>
+        data-api="/home/pricing" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="pricing-title">{{ ssr.home.section_titles.pricing if ssr and ssr.home.section_titles.pricing else '' }}</h2>
@@ -352,13 +358,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    10) INSIGHTS — blog/cases (reel)
    ================================================================ #}
 {% set blog = ssr.blog if ssr and ssr.blog else [] %}
+{% if blog %}
 <section id="insights" class="section section--altI" aria-labelledby="ins-title"
-        data-api="/blog/latest" aria-busy="false"{% if not blog %} hidden{% endif %}>
+        data-api="/blog/latest" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="ins-title">{{ ssr.home.section_titles.insights if ssr and ssr.home.section_titles.insights else '' }}</h2>
@@ -375,13 +383,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    11) FAQ — details/summary
    ================================================================ #}
 {% set faq = ssr.faq if ssr and ssr.faq else [] %}
+{% if faq %}
 <section id="faq" class="section section--faq" aria-labelledby="faq-title"
-        data-api="/faq/list" aria-busy="false"{% if not faq %} hidden{% endif %}>
+        data-api="/faq/list" aria-busy="false">
   <div class="wrap">
     <header class="section__head">
       <h2 id="faq-title">{{ ssr.home.section_titles.faq if ssr and ssr.home.section_titles.faq else '' }}</h2>
@@ -397,13 +407,15 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    12) FINAL CTA — przyciski
    ================================================================ #}
 {% set final = ssr.final if ssr and ssr.final else {} %}
+{% if final %}
 <section id="final-cta" class="section section--final" data-api="/home/final"
-        aria-labelledby="final-cta-title" aria-busy="false"{% if not final %} hidden{% endif %}>
+        aria-labelledby="final-cta-title" aria-busy="false">
   <div class="wrap">
     {% if final.title %}<h2 id="final-cta-title">{{ final.title }}</h2>{% endif %}
     {% if final.desc %}<p class="final__desc">{{ final.desc }}</p>{% endif %}
@@ -421,6 +433,7 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {# ================================================================
    Dodatkowe UI: przełącznik motywu (light/dark) — bez tekstów

--- a/tools/build.py
+++ b/tools/build.py
@@ -1023,7 +1023,7 @@ def build_all():
     for r in rows:
         if not _truthy((r.get("meta") or {}).get("publish", "true")):
             continue
-        if (r.get("type") or "page").strip().lower() not in {"page", "home"}:
+        if (r.get("type") or "page").strip().lower() not in {"page", "home", "service"}:
             continue
         pages_idx[(r.get("key"), r.get("lang"))] = r
 
@@ -1236,6 +1236,12 @@ def build_all():
                 "strings": strings_local,
                 "ssr": ssr,
             }
+            if key == "home" and L == "pl":
+                dbg_dir = Path("_debug")
+                dbg_dir.mkdir(exist_ok=True)
+                (dbg_dir / "page_home_pl.json").write_text(
+                    json.dumps(page_rec, ensure_ascii=False, indent=2), "utf-8"
+                )
             if (page_rec.get("slugKey") or "").lower() == "blog" or (page_rec.get("type") or "").lower() == "blog":
                 ctx["blog_posts"] = posts_by_lang.get(L, [])
             html = render_template(template_rel, ctx)

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -376,11 +376,13 @@ def load_all(cms_root: Path) -> Dict[str, Any]:
                         parent_key = parent_key[len(f"/{L}/"):]
                     parent_key = parent_key.strip("/")
 
+                    typ = _cell(row, hdr_lc, "type") or "page"
                     meta = {
                         "h1": _cell(row, hdr_lc, "h1"),
                         "title": _cell(row, hdr_lc, "title"),
                         "seo_title": _cell(row, hdr_lc, "seo_title"),
                         "meta_desc": _cell(row, hdr_lc, "meta_desc"),
+                        "lead": _cell(row, hdr_lc, "lead"),
                         "hero_alt": _cell(row, hdr_lc, "hero_alt"),
                         "hero_image": _cell(row, hdr_lc, "hero_image"),
                         "og_image": _cell(row, hdr_lc, "og_image"),
@@ -404,13 +406,15 @@ def load_all(cms_root: Path) -> Dict[str, Any]:
                             "slug": rel,
                             "parent_key": parent_key,
                             "template": tpl,
+                            "type": typ,
                             "order": int(float(order_v or "999")),
                             "meta": meta_clean,
                         }
                     )
                     routes.setdefault(key, {})[L] = rel
-                    pm = page_meta.setdefault(L, {}).setdefault(key, {})
-                    pm.update(meta_clean)
+                    if (typ or "").strip().lower() in {"page", "home", "service"}:
+                        pm = page_meta.setdefault(L, {}).setdefault(key, {})
+                        pm.update(meta_clean)
                 except IndexError:
                     continue
 


### PR DESCRIPTION
## Summary
- ensure base template uses CMS title/description
- ingest CMS page type/lead and avoid nav overwrites of home title
- conditionally render Home sections without placeholders
- dump home page context for debugging and upload via workflow

### page_home_pl.json
```json
{
  "seo_title": "Transport ekspresowy: busy 3,5 t i TIR — Polska & UE | Łódź",
  "h1": "Firma transportowa Łódź — ekspresowy transport busami 3,5 t i TIR w Polsce i UE",
  "title": "Transport ekspresowy: busy 3,5 t i TIR — Polska & UE | Łódź",
  "meta_desc": "Rodzinna firma transportowa z Łodzi. Transport krajowy i międzynarodowy 24/7, busy 3,5 t i TIR, szybka wycena 15 min, GPS, ubezpieczenie. Bezpiecznie i na czas."
}
```

## Testing
- `pytest tests/test_content_sync.py -q`
- `pytest -q` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68adb144fd58833397bc0de2518bdc39