### PR TITLE
feat: ingest Blocks and render on home

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -40,8 +40,8 @@
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0ea5e9" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b1020" />
 
-  {# bezpieczny tytuł: preferuj seo_title, potem h1/title, w ostateczności brand #}
-  <title>{{ page.seo_title or page.h1 or page.title or _og_title or _brand_name }}</title>
+  {# bezpieczny tytuł: seo_title → h1 → title → brand #}
+  <title>{{ page.seo_title or page.h1 or page.title or _brand_name }}</title>
   <meta name="description" content="{{ page.meta_desc or _meta_desc }}">
   {% if page.noindex %}<meta name="robots" content="noindex,follow" />{% else %}<meta name="robots" content="index,follow" />{% endif %}
   <link rel="canonical" href="{{ page.canonical or canonical }}" />
@@ -68,11 +68,11 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ _brand_name }}" />
   <meta property="og:url" content="{{ page.canonical or canonical }}" />
-  <meta property="og:title" content="{{ page.seo_title or page.title or _og_title or _brand_name }}">
+  <meta property="og:title" content="{{ page.seo_title or page.h1 or page.title or _brand_name }}">
   <meta property="og:description" content="{{ page.meta_desc or _meta_desc }}">
   <meta property="og:image" content="{{ (_site.get('url') or _site.get('base_url') or '') ~ (page.og_image or _og_image or '/assets/media/og-default.webp') }}" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="{{ page.seo_title or page.title or _og_title or _brand_name }}" />
+  <meta name="twitter:title" content="{{ page.seo_title or page.h1 or page.title or _brand_name }}" />
   <meta name="twitter:description" content="{{ page.meta_desc or _meta_desc }}" />
   <meta name="twitter:image" content="{{ (_site.get('url') or _site.get('base_url') or '') ~ (page.og_image or _og_image or '/assets/media/og-default.webp') }}" />
 

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+
+{# --- Block renderers ---------------------------------------------------- #}
+{% macro block_hero(b) -%}
+<section id="hero" class="block block-hero">
+  <div class="wrap">
+    {% if b.title %}<h1>{{ b.title }}</h1>{% endif %}
+    {% if b.lead %}<p id="hero-lead">{{ b.lead }}</p>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro block_text(b) -%}
+<section class="block block-text">
+  <div class="wrap">
+    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro block_bullets(b) -%}
+<section class="block block-bullets">
+  <div class="wrap">
+    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro block_list(b) -%}
+<section class="block block-list">
+  <div class="wrap">
+    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro block_cta(b) -%}
+<section class="block block-cta">
+  <div class="wrap">
+    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro block_kpi(b) -%}
+<section class="block block-kpi">
+  <div class="wrap">
+    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
+    {% if b.body_md %}{{ b.body_md|markdown }}{% endif %}
+    {% if b.cta_label and b.cta_href %}
+    <div class="cta-row">
+      <a class="btn btn-primary" href="{{ b.cta_href }}">{{ b.cta_label }}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{%- endmacro %}
+
+{% block content %}
+{% if page.blocks %}
+  {% for b in page.blocks %}
+    {% if b.type == 'hero' %}
+      {{ block_hero(b) }}
+    {% elif b.type == 'bullets' %}
+      {{ block_bullets(b) }}
+    {% elif b.type == 'list' %}
+      {{ block_list(b) }}
+    {% elif b.type == 'cta' %}
+      {{ block_cta(b) }}
+    {% elif b.type == 'kpi' %}
+      {{ block_kpi(b) }}
+    {% else %}
+      {{ block_text(b) }}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% endblock %}
+

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -7,6 +7,9 @@ from urllib.parse import urlsplit
 import openpyxl
 import pytest
 from bs4 import BeautifulSoup
+import sys
+sys.path.append('tools')
+import cms_ingest
 
 XLSX_PATH = Path('data/cms/menu.xlsx')
 DIST = Path('dist')
@@ -104,6 +107,37 @@ def test_pages_content_matches_cms():
                     )
                 else:
                     assert act == exp, f"{field} mismatch for {path}: {act!r} != {exp!r}"
+
+
+def test_home_has_blocks():
+    ws = load_sheet('Blocks')
+    rows = list(ws.iter_rows(values_only=True))
+    if not rows:
+        pytest.skip('no block rows')
+    header = [str(h or '').strip().lower() for h in rows[0]]
+    idx = {h: i for i, h in enumerate(header)}
+    if 'lang' not in idx or 'page' not in idx:
+        pytest.skip('unsupported blocks sheet')
+    target_lang = 'pl'
+    found = False
+    for r in rows[1:]:
+        if not r:
+            continue
+        lang = cell_str(r[idx['lang']]).lower()
+        page = cell_str(r[idx['page']]).lower()
+        enabled = truthy(r[idx.get('enabled')]) if 'enabled' in idx else True
+        if lang == target_lang and page == 'home' and enabled:
+            found = True
+            break
+    if not found:
+        pytest.skip('no enabled home blocks for lang')
+
+    import openpyxl as ox
+    wb = ox.load_workbook(XLSX_PATH, read_only=True, data_only=True)
+    cms = cms_ingest.load_all(Path('data')/ 'cms')
+    routes = cms.get('routes', {})
+    blocks = cms_ingest.load_blocks_for_lang(wb, target_lang, routes)
+    assert blocks and len(blocks) > 0
 
 
 def test_nav_menu_matches_cms():

--- a/tools/build.py
+++ b/tools/build.py
@@ -989,8 +989,18 @@ def build_all():
     rows = cms.get("pages_rows") or []
     routes = CMS.get("routes") or {}
     page_routes = routes
-
-    blocks_by_page_lang = cms.get("blocks_by_page_lang", {})
+    # Blocks: load for each language (page 'home')
+    try:
+        import openpyxl
+        wb_blocks = openpyxl.load_workbook(cms_ingest.XLSX, read_only=True, data_only=True)
+    except Exception:
+        wb_blocks = None
+    blocks_by_page_lang = {}
+    if wb_blocks is not None:
+        for L in languages:
+            bs = cms_ingest.load_blocks_for_lang(wb_blocks, L, routes)
+            if bs:
+                blocks_by_page_lang[(L, "home")] = bs
     faq_by_page_lang = cms.get("faq_by_page_lang", {})
 
     BLOG = [r for r in CMS.get("blog", []) if (r.get("type") or "").strip().lower() == "blog_post"]
@@ -1220,6 +1230,8 @@ def build_all():
             page_key = key
             meta = page_rec.get("meta") or {}
             strings_local = {k: (v.get(L) or v.get(dlang) or "") for k, v in strings_map.items()}
+            page_blocks = blocks_by_page_lang.get((L, page_key), []) if isinstance(blocks_by_page_lang, dict) else []
+            page_rec["blocks"] = page_blocks
             ctx = {
                 "lang": L,
                 "site": SITE,
@@ -1232,7 +1244,7 @@ def build_all():
                 "title": page_rec.get("seo_title") or page_rec.get("title") or SITE.get("brand") or SITE.get("title"),
                 "h1": page_rec.get("h1") or page_rec.get("title") or "",
                 "meta_desc": page_rec.get("meta_desc") or "",
-                "blocks": (blocks_by_page_lang.get((L, page_key)) if isinstance(blocks_by_page_lang, dict) else {}),
+                "blocks": page_blocks,
                 "faq": (faq_by_page_lang.get((L, page_key)) if isinstance(faq_by_page_lang, dict) else []),
                 "canonical": canonical,
                 "STR": lambda key, _L=L: STR(_L, key),

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -50,6 +50,133 @@ def split_slug(slug: str):
     rel = (m.group(2) or "").strip("/")
     return lang, rel
 
+
+def truthy(v: Any) -> bool:
+    """Return True for common "truthy" string values."""
+    return str(v or "").strip().lower() in {
+        "1",
+        "true",
+        "tak",
+        "yes",
+        "on",
+        "prawda",
+    }
+
+
+def looks_like_slugkey(val: str) -> bool:
+    """Heuristic check whether ``val`` resembles a slugKey.
+
+    SlugKeys are short alphanumeric identifiers without slashes or schemes.
+    """
+    s = (val or "").strip()
+    if not s:
+        return False
+    if any(ch in s for ch in "/:#?"):
+        return False
+    return re.fullmatch(r"[A-Za-z0-9_-]+", s) is not None
+
+
+def map_href(lang: str, href_or_slugkey: str, routes: Dict[str, Dict[str, str]]) -> str:
+    """Map ``href_or_slugkey`` to final href for language ``lang``.
+
+    If value resembles a slugKey it will be resolved through ``routes`` to
+    ``/{lang}/{rel}/``; otherwise raw href is returned.
+    """
+    raw = (href_or_slugkey or "").strip()
+    if not raw:
+        return ""
+    if looks_like_slugkey(raw):
+        rel = (routes.get(raw, {}) or {}).get(lang)
+        if rel is None:
+            rel = raw if raw != "home" else ""
+        rel = str(rel or "").strip("/")
+        return f"/{lang}/" if not rel else f"/{lang}/{rel}/"
+    return raw
+
+
+def load_blocks_for_lang(wb, lang: str, routes: Dict[str, Dict[str, str]]) -> List[Dict[str, Any]]:
+    """Load Blocks for selected language.
+
+    Only enabled blocks for page ``home`` are returned. Supported block types:
+    hero, text, bullets, list, cta and kpi. Both ``body_md`` and ``body_md_1``
+    columns are accepted. Links are resolved with :func:`map_href`.
+    """
+    ws = None
+    for name in wb.sheetnames:
+        if str(name).strip().lower() == "blocks":
+            ws = wb[name]
+            break
+    if ws is None:
+        return []
+
+    rows = list(ws.iter_rows(values_only=True))
+    if not rows:
+        return []
+    header = [str(h or "").strip().lower() for h in rows[0]]
+    idx = {h: i for i, h in enumerate(header)}
+
+    allowed = {"hero", "text", "bullets", "list", "cta", "kpi"}
+    out: List[Dict[str, Any]] = []
+    L = (lang or "").lower()
+
+    for row in rows[1:]:
+        if not row:
+            continue
+        row_lang = str(row[idx.get("lang", 0)] or "").strip().lower()
+        if row_lang != L:
+            continue
+        page = str(row[idx.get("page", 0)] or "").strip().lower()
+        if page != "home":
+            continue
+        if "enabled" in idx and not truthy(row[idx.get("enabled")]):
+            continue
+        typ = str(row[idx.get("type", 0)] or "text").strip().lower()
+        if typ not in allowed:
+            continue
+
+        blk: Dict[str, Any] = {"type": typ}
+        order_val = row[idx.get("order")] if idx.get("order") is not None else 0
+        try:
+            blk["order"] = float(order_val) if order_val is not None else 0
+        except Exception:
+            blk["order"] = 0
+
+        body_md = ""
+        if "body_md" in idx:
+            val = row[idx["body_md"]]
+            body_md = "" if val is None else str(val).strip()
+        if not body_md and "body_md.1" in idx:
+            val = row[idx["body_md.1"]]
+            body_md = "" if val is None else str(val).strip()
+        if body_md:
+            blk["body_md"] = body_md
+
+        for fld in ("block", "title", "lead", "desc"):
+            i = idx.get(fld)
+            if i is not None and i < len(row):
+                v = row[i]
+                if v is not None and str(v).strip():
+                    blk[fld] = str(v).strip()
+
+        if "href" in idx:
+            href_raw = row[idx["href"]]
+            if href_raw:
+                blk["href"] = map_href(L, str(href_raw).strip(), routes)
+
+        if "cta_label" in idx:
+            lbl = row[idx["cta_label"]]
+            if lbl:
+                blk["cta_label"] = str(lbl).strip()
+        if "cta_href" in idx:
+            h = row[idx["cta_href"]]
+            if h:
+                blk["cta_href"] = map_href(L, str(h).strip(), routes)
+
+        out.append(blk)
+
+    out.sort(key=lambda b: b.get("order", 0))
+    return out
+
 SYN = {
   # kolumny dla arkuszy z definicjami stron
   "pages": {


### PR DESCRIPTION
## Summary
- ingest Blocks sheet with slug-key aware href mapping
- render home blocks via new page template and per-page context
- prioritize seo_title → h1 → title → brand in head tags

## Testing
- `python tools/build.py`
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68adc21a61708333b42bd158f7f16c33