### PR TITLE
feat(cms): expose SSR payload built from Blocks; add body_html; keep Pages as source of truth for head

### DIFF
--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -140,6 +140,35 @@ def test_home_has_blocks():
     assert blocks and len(blocks) > 0
 
 
+def test_home_blocks_rendered():
+    ws = load_sheet('Blocks')
+    rows = list(ws.iter_rows(values_only=True))
+    header = [str(h or '').strip().lower() for h in rows[0]]
+    idx = {h: i for i, h in enumerate(header)}
+    if {'lang', 'page', 'block', 'title'}.difference(idx):
+        pytest.skip('unsupported blocks sheet')
+    titles = []
+    target_lang = 'pl'
+    for r in rows[1:]:
+        if not r:
+            continue
+        lang = cell_str(r[idx['lang']]).lower()
+        page = cell_str(r[idx['page']]).lower()
+        block = cell_str(r[idx['block']]).lower()
+        enabled = truthy(r[idx.get('enabled')]) if 'enabled' in idx else True
+        if lang == target_lang and page == 'home' and block == 'home.industries' and enabled:
+            t = cell_str(r[idx.get('title')])
+            if t:
+                titles.append(t)
+    if not titles:
+        pytest.skip('no home.industries blocks')
+    path = DIST / target_lang / 'index.html'
+    assert path.exists(), f'missing {path}'
+    html = path.read_text(encoding='utf-8')
+    for t in titles:
+        assert t in html
+
+
 def test_nav_menu_matches_cms():
     ws = load_sheet('Nav')
     rows = list(ws.iter_rows(values_only=True))

--- a/tools/build.py
+++ b/tools/build.py
@@ -179,6 +179,53 @@ def _ssr_home(lang:str) -> Dict[str, Any]:
         "routes": _routes_map()
     }
 
+def build_ssr(blocks_by_lang_page: Dict[Tuple[str, str], List[Dict[str, Any]]]) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """Build simplified SSR payload for pages from ``Blocks`` rows.
+
+    Returned mapping uses ``(lang, page)`` as keys and for each entry provides
+    sections listed in the home template. ``hero`` is a single block, all other
+    sections are lists. ``routes`` are always included for slugKey lookups.
+    """
+    sections = [
+        "services",
+        "industries",
+        "coverage",
+        "process",
+        "trust",
+        "testimonials",
+        "partners",
+        "fleet",
+        "pricing",
+        "blog",
+        "faq",
+        "final",
+    ]
+    out: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    routes = _routes_map()
+
+    for (lang, page), blocks in (blocks_by_lang_page or {}).items():
+        ssr_entry: Dict[str, Any] = {
+            "hero": {},
+            "routes": routes,
+        }
+        for name in sections:
+            ssr_entry[name] = []
+
+        for blk in blocks or []:
+            bid = (blk.get("block") or "").strip().lower()
+            typ = (blk.get("type") or "").strip().lower()
+            if bid.endswith(".hero") or typ == "hero":
+                ssr_entry["hero"] = blk
+            else:
+                for name in sections:
+                    if bid.endswith(f".{name}"):
+                        ssr_entry[name].append(blk)
+                        break
+
+        out[(lang, page)] = ssr_entry
+
+    return out
+
 # --------------------------- POMOCNICZE ------------------------------------
 ROOT = Path(".")
 DIST = Path("dist")
@@ -428,6 +475,12 @@ def resolve_template(page: Dict[str, Any]) -> str:
 def md_to_html(md_text: str) -> str:
     if not md_text:
         return ""
+    try:
+        f = env.filters.get("markdown")  # type: ignore[name-defined]
+    except Exception:
+        f = None
+    if callable(f):
+        return f(md_text)
     return MD.render(md_text)
 
 def soupify(html: str) -> BeautifulSoup:
@@ -987,6 +1040,8 @@ def build_all():
     if nav_rows:
         nav_by_lang = _nav_data_from_rows(nav_rows, nav_fallback)
     rows = cms.get("pages_rows") or []
+    for r in rows:
+        r["body_html"] = md_to_html(r.get("body_md", ""))
     routes = CMS.get("routes") or {}
     page_routes = routes
     # Blocks: load for each language (page 'home')
@@ -1001,6 +1056,7 @@ def build_all():
             bs = cms_ingest.load_blocks_for_lang(wb_blocks, L, routes)
             if bs:
                 blocks_by_page_lang[(L, "home")] = bs
+    ssr_by_page_lang = build_ssr(blocks_by_page_lang)
     faq_by_page_lang = cms.get("faq_by_page_lang", {})
 
     BLOG = [r for r in CMS.get("blog", []) if (r.get("type") or "").strip().lower() == "blog_post"]
@@ -1197,26 +1253,8 @@ def build_all():
             page_fields = _page_fields(page_rec)
             page_rec.update(page_fields)
 
-            ssr: Dict[str, Any] = {
-                "hero": {
-                    "title": page_fields["h1"] or page_fields["title"],
-                    "lead": page_fields["lead"],
-                    "claim": "",
-                    "kpi": [],
-                    "image": {
-                        "src": page_rec.get("hero_image") or page_rec.get("og_image") or "",
-                        "srcset": "",
-                        "alt": page_rec.get("hero_alt") or page_fields["h1"] or page_fields["title"],
-                    },
-                    "cta": {"label": page_fields["cta_label"]},
-                    "cta_primary": {"label": page_fields["cta_label"]},
-                    "cta_secondary": {"label": page_rec.get("cta_secondary", "")},
-                },
-                "services": [],
-                "faq": [],
-                "home": {"section_titles": {}, "section_subtitles": {}},
-                "routes": routes,
-            }
+            ssr = ssr_by_page_lang.get((L, key), {})
+            ssr.setdefault("routes", routes)
 
             template_rel = resolve_template(page_rec)
 


### PR DESCRIPTION
## Summary
- build SSR payload from XLSX Blocks for sections like hero, services and industries
- render page body Markdown into HTML and expose block SSR data in templates
- smoke test ensures Blocks content (e.g. industries titles) appears in built home page

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adc96b9ea083339a5c4483124ee4ab