### PR TITLE
test/home-content

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,17 +50,6 @@ jobs:
           pip install --upgrade playwright
           python -m playwright install --with-deps chromium
 
-      - name: Run tests
-        if: ${{ hashFiles('tests/**') != '' }}
-        run: |
-          source .venv/bin/activate
-          pytest -q
-
-      # Jeśli chcesz tymczasowo ominąć test z Playwright:
-      # run: |
-      #   source .venv/bin/activate
-      #   pytest -q -k 'not dropdown_keyboard'
-
       - name: Provide CMS (repo-only)
         run: |
           set -euo pipefail
@@ -118,6 +107,17 @@ jobs:
           set -e
           source .venv/bin/activate
           python tools/cms_verify_build.py
+
+      - name: Run tests
+        if: ${{ hashFiles('tests/**') != '' }}
+        run: |
+          source .venv/bin/activate
+          pytest -q
+
+      # Jeśli chcesz tymczasowo ominąć test z Playwright:
+      # run: |
+      #   source .venv/bin/activate
+      #   pytest -q -k 'not dropdown_keyboard'
       - name: Upload debug JSON
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/tests/test_home_content.py
+++ b/tests/test_home_content.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_home_has_content():
+    p = Path('dist/pl/index.html').read_text('utf-8')
+    assert '<h1' in p
+    assert 'id="hero-lead"' in p or 'class="hero__lead"' in p
+    assert 'class="section block' in p  # przynajmniej 1 blok z arkusza


### PR DESCRIPTION
## Summary
- add regression test ensuring generated home page contains main elements
- run tests in pages workflow only after the build completes

## Testing
- `python tools/build.py`
- `pytest -q` *(fails: assert '<h1' in dist/pl/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68ade251a0888333967b20c49bed39b4