### PR TITLE
fix/markdown-html

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -17,12 +17,12 @@
   |sort(attribute='order')
   |list
 ) %}
-{% for b in BLOCKS %}
-  <section class="section block block--{{ b.block }}">
-    {% if b.title %}<h2>{{ b.title }}</h2>{% endif %}
-    {% if b.lead %}<p class="lead">{{ b.lead }}</p>{% endif %}
-    {% if b.body_html %}<div class="content">{{ b.body_html|safe }}</div>{% endif %}
-    {% if b.cta_label and b.cta_href %}<div class="cta-row"><a class="btn" href="{{ b.cta_href }}">{{ b.cta_label }}</a></div>{% endif %}
+{% for blk in BLOCKS %}
+  <section class="section block block--{{ blk.block }}">
+    {% if blk.title %}<h2>{{ blk.title }}</h2>{% endif %}
+    {% if blk.lead %}<p class="lead">{{ blk.lead }}</p>{% endif %}
+    {% if blk.body_html %}<div class="content">{{ blk.body_html|safe }}</div>{% endif %}
+    {% if blk.cta_label and blk.cta_href %}<div class="cta-row"><a class="btn" href="{{ blk.cta_href }}">{{ blk.cta_label }}</a></div>{% endif %}
   </section>
 {% endfor %}
 {% set FAQ = (

--- a/tests/test_markdown_compilation.py
+++ b/tests/test_markdown_compilation.py
@@ -1,0 +1,26 @@
+from openpyxl import Workbook, load_workbook
+import sys
+sys.path.append('tools')
+import build
+
+
+def test_markdown_heading_compilation(tmp_path):
+    # Create temporary XLSX with Markdown heading
+    wb = Workbook()
+    ws = wb.active
+    ws.title = 'Pages'
+    ws.append(['body_md'])
+    ws.append(['## XXX'])
+    xlsx_path = tmp_path / 'sample.xlsx'
+    wb.save(xlsx_path)
+
+    # Load rows using builder helper
+    sheet = load_workbook(xlsx_path).active
+    rows = build.load_rows(sheet)
+    assert rows[0]['body_md'] == '## XXX'
+
+    # Compile Markdown to HTML
+    html = build.md_to_html(rows[0]['body_md'])
+    assert '<h2>XXX</h2>' in html
+    assert '##' not in html
+

--- a/tools/build.py
+++ b/tools/build.py
@@ -74,7 +74,7 @@ def truthy(v):
     return s in {'true','1','yes','y','tak','t','x'}
 
 def md_to_html(s):
-    return markdown(s or '')
+    return markdown(s or '', extensions=["extra", "sane_lists"])
 
 def load_rows(sheet):
     if sheet is None:


### PR DESCRIPTION
## Summary
- ensure Markdown bodies compile to HTML using Markdown extras
- render compiled HTML for page and block bodies in templates
- verify Markdown headings convert to `<h2>` tags

## Testing
- `pytest tests/test_markdown_compilation.py -q`
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist)*
- `yamllint pages.yml` *(fails: line too long and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae07490e5483338b0d3045c7f56ade