### PR TITLE
feat/nav-bundler

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -1,11 +1,11 @@
 /* Mega-menu SWR-only:
    - NIE renderuje na starcie (używamy SSR z HTML-a)
    - TYLKO sprawdza wersję bundla i w razie zmiany podmienia menu
-   - pobiera z /assets/nav/bundle_{lang}.json (fix 404) */
+   - pobiera z /assets/data/menu/bundle_{lang}.json */
 (function(){
   const UL_ID = 'navList';
   const META_NAME = 'menu-bundle-version';
-  const PREFIX = '/assets/nav';
+  const PREFIX = '/assets/data/menu';
 
   const $ = s => document.querySelector(s);
 

--- a/tests/test_nav_bundles.py
+++ b/tests/test_nav_bundles.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+def _iter_items(items):
+    for it in items or []:
+        yield it
+        for ch in _iter_items(it.get('children')):
+            yield ch
+
+def test_nav_bundles():
+    dir_path = Path('dist/assets/data/menu')
+    assert dir_path.exists(), 'menu bundles missing'
+    for p in dir_path.glob('bundle_*.json'):
+        data = json.loads(p.read_text(encoding='utf-8'))
+        meta = data.get('meta', {})
+        assert meta.get('logo', {}).get('src'), f"{p.name} missing logo.src"
+        assert meta.get('cta', {}).get('label'), f"{p.name} missing cta.label"
+        for it in _iter_items(data.get('items')):
+            href = it.get('href', '')
+            if href.startswith('/'):
+                assert href.endswith('/'), f"{p.name} href '{href}' missing slash"
+        for it in data.get('items', []):
+            assert not it.get('parent'), f"{p.name} top-level item has parent"

--- a/tools/build.py
+++ b/tools/build.py
@@ -508,6 +508,32 @@ def _nav_data_from_rows(rows, fallback):
     return out
 
 
+def _build_nav_bundle_for_lang(rows: List[Dict[str, Any]], lang: str, meta: Dict[str, Any]) -> Dict[str, Any]:
+    """Build new navigation bundle for selected language."""
+    arr = [r for r in rows if (r.get("lang") or "pl").lower() == lang]
+    children = defaultdict(list)
+    mains = []
+    for r in arr:
+        parent = (r.get("parent") or "").strip()
+        if parent:
+            children[parent].append(r)
+        else:
+            mains.append(r)
+    def _node(rec: Dict[str, Any]) -> Dict[str, Any]:
+        node = {"label": rec.get("label"), "href": rec.get("href"), "order": rec.get("order", 0)}
+        kids = children.get(rec.get("label"), [])
+        if kids:
+            kids.sort(key=lambda i: (i.get("order", 0), (i.get("label") or "").lower()))
+            node["children"] = [_node(ch) for ch in kids]
+        return node
+    mains.sort(key=lambda i: (i.get("order", 0), (i.get("label") or "").lower()))
+    items = [_node(m) for m in mains]
+    bundle = {"meta": meta or {}, "items": items}
+    h = hashlib.sha256(json.dumps(bundle, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")).hexdigest()
+    bundle["version"] = f"sha256:{h}"
+    return bundle
+
+
 from pathlib import Path
 
 def _split_lang_rel(slug: str):
@@ -1276,6 +1302,7 @@ def build_all():
 
     # === MENU: jeśli są wiersze z arkusza → buduj bundlery + HTML do SSR ===
     rows = cms.get("menu_rows") or []
+    meta_by_lang = cms.get("nav_meta", {})
     if not rows:
         def _menu_from_pages(pages_rows):
             out=[]
@@ -1298,10 +1325,13 @@ def build_all():
         print("[cms] menu_rows empty → built from pages_rows")
     if rows:
         bundles, html_by_lang = {}, {}
+        meta_default = meta_by_lang.get(site_cfg.get("default_lang", "pl"), {})
         for L in languages:
-            b = menu_builder.build_bundle_for_lang(rows, L)
-            bundles[L] = b
-            html_by_lang[L] = menu_builder.render_nav_html(b)
+            html_bundle = menu_builder.build_bundle_for_lang(rows, L)
+            html_by_lang[L] = menu_builder.render_nav_html(html_bundle)
+            meta = dict(meta_default)
+            meta.update(meta_by_lang.get(L, {}))
+            bundles[L] = _build_nav_bundle_for_lang(rows, L, meta)
         # zapisz bundlery do nowej i legacy ścieżki (żeby nie było 404)
         out_new = DIST / "assets" / "data" / "menu"
         out_old = DIST / "assets" / "nav"

--- a/tools/cms_ingest.py
+++ b/tools/cms_ingest.py
@@ -397,6 +397,7 @@ def load_all(cms_root: Path) -> Dict[str, Any]:
     media_rows: List[Dict[str, Any]] = []
     company_rows: List[Dict[str, Any]] = []
     redirect_rows: List[Dict[str, Any]] = []
+    nav_meta: Dict[str, Dict[str, Any]] = {}
 
     for ws in wb.worksheets:
         rows = list(ws.iter_rows(values_only=True))
@@ -566,11 +567,45 @@ def load_all(cms_root: Path) -> Dict[str, Any]:
                         continue
                     label = _cell(row, hdr_lc, "label")
                     href = _cell(row, hdr_lc, "href")
+                    meta_candidate: Dict[str, Any] = {}
+                    logo_src = _cell(row, hdr_lc, "nav.logo.src")
+                    if logo_src:
+                        meta_candidate.setdefault("logo", {})["src"] = logo_src
+                    logo_alt = _cell(row, hdr_lc, "nav.logo.alt")
+                    if logo_alt:
+                        meta_candidate.setdefault("logo", {})["alt"] = logo_alt
+                    cta_label = _cell(row, hdr_lc, "nav.cta.label")
+                    cta_slug = _cell(row, hdr_lc, "nav.cta.slugkey")
+                    if cta_label or cta_slug:
+                        meta_candidate.setdefault("cta", {})
+                        if cta_label:
+                            meta_candidate["cta"]["label"] = cta_label
+                        if cta_slug:
+                            meta_candidate["cta"]["slugKey"] = cta_slug
+                    for k in ("ig", "li", "fb"):
+                        v = _cell(row, hdr_lc, f"nav.social.{k}")
+                        if v:
+                            meta_candidate.setdefault("social", {})[k] = v
+                    if meta_candidate and L not in nav_meta:
+                        nav_meta[L] = meta_candidate
+                    if not label and not href:
+                        continue
                     if not label or not href:
                         continue
                     parent = _cell(row, hdr_lc, "parent") or ""
                     order_v = _cell(row, hdr_lc, "order") or "999"
                     col_v = _cell(row, hdr_lc, "col") or "1"
+                    h = href
+                    if h.startswith('/'):
+                        idx = len(h)
+                        for sep in ('#', '?'):
+                            pos = h.find(sep)
+                            if pos != -1 and pos < idx:
+                                idx = pos
+                        base, suf = h[:idx], h[idx:]
+                        if not base.endswith('/'):
+                            base += '/'
+                        href = base + suf
                     menu_rows.append(
                         {
                             "lang": L,
@@ -774,6 +809,7 @@ def load_all(cms_root: Path) -> Dict[str, Any]:
 
     return {
         "menu_rows": menu_rows,
+        "nav_meta": nav_meta,
         "page_meta": page_meta,
         "blocks": blocks,
         "page_routes": routes,


### PR DESCRIPTION
## Summary
- ingest Nav sheet metadata and items, bundling per language
- build navigation bundles with meta and order, served from assets/data/menu
- update frontend to load new bundles and add tests for bundle structure

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `python tools/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae09cf3b6483339f61eed20e0b4bce