### PR TITLE
fix/blocks-normalize

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -3,23 +3,16 @@
 
 {# ====== Alias i kontekst ====== #}
 {% set pg   = pg or page or {} %}
-{% set _slug = (pg.slugKey or pg.slug or page.slugKey or page.slug or 'home') %}
-{% set _lang = (pg.lang or page.lang or site.defaultLang or 'pl') %}
+{% set _slug = (pg.slugKey or pg.slug or page.slugKey or page.slug or 'home')|trim|lower %}
+{% set _lang = (pg.lang or page.lang or site.defaultLang or 'pl')|trim|lower %}
 
-{# ====== Pobierz bloki dla tej strony i języka (z fallbackiem do defaultLang) ====== #}
-{% set _blocks_lang = (blocks
-  |selectattr('lang','equalto',_lang)
-  |list) if blocks is defined else [] %}
-{% if _blocks_lang|length == 0 and site and site.defaultLang %}
-  {% set _blocks_lang = (blocks
-    |selectattr('lang','equalto',site.defaultLang)
-    |list) if blocks is defined else [] %}
-{% endif %}
-{% set BLOCKS = (_blocks_lang
-  |selectattr('enabled','ne',False)
+{# ====== Pobierz bloki dla tej strony i języka ====== #}
+{% set BLOCKS = (blocks
+  |selectattr('enabled','equalto',True)
   |selectattr('page','equalto',_slug)
+  |selectattr('lang','equalto',_lang)
   |sort(attribute='order')
-  |list) %}
+  |list) if blocks is defined else [] %}
 
 {# ====== Prostutki „parser” Markdown (H2/H3, listy, akapity, usuwanie **) ====== #}
 {% macro _clean(s) -%}

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -7,11 +7,11 @@
   {% if page.cta_label %}<a id="cta" class="btn" href="{{ page.cta_href or '#' }}">{{ page.cta_label }}</a>{% endif %}
 </section>
 {% if page.body_html %}<article class="content">{{ page.body_html|safe }}</article>{% endif %}
-{% set _slug = page.slugKey or 'home' %}
-{% set _lang = page.lang or site.defaultLang or 'pl' %}
+{% set _slug = (page.slugKey or 'home')|trim|lower %}
+{% set _lang = (page.lang or site.defaultLang or 'pl')|trim|lower %}
 {% set BLOCKS = (
   blocks
-  |selectattr('enabled','ne',False)
+  |selectattr('enabled','equalto',True)
   |selectattr('page','equalto',_slug)
   |selectattr('lang','equalto',_lang)
   |sort(attribute='order')
@@ -27,7 +27,7 @@
 {% endfor %}
 {% set FAQ = (
   faq
-  |selectattr('enabled','ne',False)
+  |selectattr('enabled','equalto',True)
   |selectattr('page','equalto',_slug)
   |selectattr('lang','equalto',_lang)
   |sort(attribute='order')

--- a/tests/test_blocks_filtering.py
+++ b/tests/test_blocks_filtering.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import subprocess
+import sys
+from openpyxl import load_workbook
+
+
+def test_blocks_filtering(tmp_path):
+    src = Path('data/cms/menu.xlsx')
+    backup = tmp_path / 'menu.xlsx.bak'
+    backup.write_bytes(src.read_bytes())
+    try:
+        wb = load_workbook(src)
+        ws = wb['Blocks']
+        header = [cell.value for cell in ws[1]]
+        header_lc = [str(h or '').strip().lower() for h in header]
+
+        def idx(name: str):
+            try:
+                return header_lc.index(name)
+            except ValueError:
+                return None
+
+        row = [''] * len(header)
+        i = idx('block')
+        if i is not None:
+            row[i] = 'testblock'
+        i = idx('lang')
+        if i is not None:
+            row[i] = 'PL '
+        i = idx('page')
+        if i is not None:
+            row[i] = ' home '
+        i = idx('body_md')
+        if i is not None:
+            row[i] = 'Testing block body'
+        i = idx('enabled')
+        if i is not None:
+            row[i] = '1'
+        ws.append(row)
+        wb.save(src)
+
+        subprocess.run([sys.executable, 'tools/build.py'], check=True)
+        html = Path('dist/pl/index.html').read_text('utf-8')
+        assert 'Testing block body' in html
+    finally:
+        src.write_bytes(backup.read_bytes())
+        subprocess.run([sys.executable, 'tools/build.py'], check=True)

--- a/tools/build.py
+++ b/tools/build.py
@@ -1199,16 +1199,23 @@ def build_all():
 
     blocks_all: List[Dict[str, Any]] = []
     for r in blocks_rows_raw:
+        lang = (r.get("lang") or "").strip().lower()
+        page = (r.get("page") or "").strip().lower()
+        order_val = r.get("order")
+        try:
+            order = int(float(order_val)) if order_val not in ("", None) else 9999
+        except Exception:
+            order = 9999
         rec = {
             "block": r.get("block"),
-            "lang": norm(r.get("lang")).lower(),
-            "page": norm(r.get("page")).lower(),
+            "lang": lang,
+            "page": page,
             "title": r.get("title") or "",
             "lead": r.get("lead") or "",
             "body_md": r.get("body_md") or "",
             "cta_label": r.get("cta_label") or "",
             "cta_href": r.get("cta_href") or "",
-            "order": int(r.get("order") or 0),
+            "order": order,
             "enabled": truthy(r.get("enabled", True)),
         }
         if rec["body_md"]:


### PR DESCRIPTION
## Summary
- Normalize Blocks `page`/`lang` during build and treat missing order as 9999
- Filter blocks strictly by slug and language in page templates
- Test that Blocks with spaced/upper values still render for `/pl/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c8f7d908333af90c197a0dbc115