### PR TITLE
guard/no-placeholders

### DIFF
--- a/tests/test_no_placeholders.py
+++ b/tests/test_no_placeholders.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+FORBIDDEN = [
+    "Jan Kowalski",
+    "Wskaźnik",
+    "Ubezp.",
+    "Lorem",
+    "ipsum",
+    "[TODO]",
+    "Placeholder",
+    "Acme",
+    "Nazwa firmy",
+]
+
+
+def test_no_custom_placeholders():
+    dist = Path("dist")
+    assert dist.exists(), "dist directory missing"
+    for path in dist.rglob("*.html"):
+        text = path.read_text(encoding="utf-8")
+        for phrase in FORBIDDEN:
+            assert phrase not in text, f"{path}: {phrase}"


### PR DESCRIPTION
## Summary
- add test ensuring dist HTML files contain no placeholder strings

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist and playwright install forbidden)*
- `playwright install` *(fails: Download failed: server returned code 403)*
- `pytest tests/test_no_placeholders.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ae0f34db848333849ab6f88ac71f66